### PR TITLE
Add logger into around Marketo API requests

### DIFF
--- a/test/embulk/input/test_marketo.rb
+++ b/test/embulk/input/test_marketo.rb
@@ -16,7 +16,7 @@ module Embulk
       def setup_plugin
         @page_builder = Object.new
         @plugin = Marketo.new(task, nil, nil, @page_builder)
-        stub(@plugin).logger { ::Logger.new(File::NULL) }
+        stub(Embulk).logger { ::Logger.new(File::NULL) }
       end
 
       def test_transaction


### PR DESCRIPTION
Use logger for SOAP requests information display.

Sample output:
```
2015-07-06 11:27:07.567 +0900: Embulk v0.6.15
2015-07-06 11:27:10.834 +0900 [INFO] (transaction): Loaded plugin embulk-input-marketo (0.0.1)
2015-07-06 11:27:10.908 +0900 [INFO] (transaction): {done:  0 / 1, running: 0}
2015-07-06 11:27:10.945 +0900 [INFO] (task-0000): Writing local file './sample000.00..csv'
2015-07-06 11:27:13.168 +0900 [INFO] (task-0000): SOAP request: https://****.mktoapi.com/soap/mktows/2_9
2015-07-06 11:27:13.168 +0900 [INFO] (task-0000): SOAPAction: "http://www.marketo.com/mktows/getMultipleLeads", Content-Type: text/xml;charset=UTF-8, Content-Length: 809
2015-07-06 11:27:30.201 +0900 [INFO] (task-0000): SOAP response (status 200)
2015-07-06 11:27:30.329 +0900 [INFO] (task-0000): Remaining records: 318
2015-07-06 11:27:32.465 +0900 [INFO] (task-0000): SOAP request: https://***.mktoapi.com/soap/mktows/2_9
2015-07-06 11:27:32.465 +0900 [INFO] (task-0000): SOAPAction: "http://www.marketo.com/mktows/getMultipleLeads", Content-Type: text/xml;charset=UTF-8, Content-Length: 892
2015-07-06 11:27:49.691 +0900 [INFO] (task-0000): SOAP response (status 200)
2015-07-06 11:27:49.749 +0900 [INFO] (task-0000): Remaining records: 218
```