### PR TITLE
Avoid 500 error

### DIFF
--- a/lib/embulk/input/marketo_api/soap.rb
+++ b/lib/embulk/input/marketo_api/soap.rb
@@ -88,7 +88,7 @@ module Embulk
                 wsdl: wsdl,
                 soap_header: headers,
                 endpoint: endpoint,
-                open_timeout: 10,
+                open_timeout: 90,
                 read_timeout: 300,
                 raise_errors: true,
                 namespace_identifier: :ns1,

--- a/lib/embulk/input/marketo_api/soap.rb
+++ b/lib/embulk/input/marketo_api/soap.rb
@@ -30,7 +30,7 @@ module Embulk
             attributes!: {
               lead_selector: {"xsi:type" => "ns1:LastUpdateAtSelector"}
             },
-            batch_size: 100,
+            batch_size: 1000,
           }
 
           stream_position = fetch_leads(request, &block)

--- a/lib/embulk/input/marketo_api/soap.rb
+++ b/lib/embulk/input/marketo_api/soap.rb
@@ -75,26 +75,25 @@ module Embulk
         end
 
         def savon
-          @savon ||=
-            begin
-              headers = {
-                'ns1:AuthenticationHeader' => {
-                  "mktowsUserId" => user_id,
-                }.merge(signature)
-              }
-              Savon.client(
-                log: true,
-                logger: Embulk.logger,
-                wsdl: wsdl,
-                soap_header: headers,
-                endpoint: endpoint,
-                open_timeout: 90,
-                read_timeout: 300,
-                raise_errors: true,
-                namespace_identifier: :ns1,
-                env_namespace: 'SOAP-ENV'
-              )
-            end
+          headers = {
+            'ns1:AuthenticationHeader' => {
+              "mktowsUserId" => user_id,
+            }.merge(signature)
+          }
+          # NOTE: Do not memoize this to use always fresh signature (avoid 20016 error)
+          # ref. https://jira.talendforge.org/secure/attachmentzip/unzip/167201/49761%5B1%5D/Marketo%20Enterprise%20API%202%200.pdf (41 page)
+          Savon.client(
+            log: true,
+            logger: Embulk.logger,
+            wsdl: wsdl,
+            soap_header: headers,
+            endpoint: endpoint,
+            open_timeout: 90,
+            read_timeout: 300,
+            raise_errors: true,
+            namespace_identifier: :ns1,
+            env_namespace: 'SOAP-ENV'
+          )
         end
 
         def signature

--- a/test/embulk/input/marketo_api/test_soap.rb
+++ b/test/embulk/input/marketo_api/test_soap.rb
@@ -21,7 +21,7 @@ module Embulk
         class TestLeadMetadata < self
           def setup
             @savon = soap.__send__(:savon)
-            stub(soap).savon { @savon }
+            stub(soap).savon { @savon } # Pin savon instance for each call soap.savon for mocking/stubbing
           end
 
           def test_savon_call

--- a/test/embulk/input/marketo_api/test_soap.rb
+++ b/test/embulk/input/marketo_api/test_soap.rb
@@ -21,6 +21,7 @@ module Embulk
         class TestLeadMetadata < self
           def setup
             @savon = soap.__send__(:savon)
+            stub(soap).savon { @savon }
           end
 
           def test_savon_call

--- a/test/embulk/input/test_marketo.rb
+++ b/test/embulk/input/test_marketo.rb
@@ -60,7 +60,7 @@ module Embulk
           {
             lead_selector: {oldest_updated_at: Time.parse(last_updated_at).iso8601},
             attributes!: {lead_selector: {"xsi:type"=>"ns1:LastUpdateAtSelector"}},
-           batch_size: 100
+            batch_size: 1000
           }
         end
       end


### PR DESCRIPTION
Sometimes Marketo SOAP API returns 500 (SOAP 20016 error).
That means "signature is too old", so use fresh signature in every request.