### PR TITLE
Avoid timeout for marketo/lead input

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Below parameters are shown in "Admin" > "Web Services" page in Marketo.
 
 ### market/lead
 
+**NOTE: If you use feature of scheduled execution (resume) with marketo/read, you should not specify until\_at because this plugin can't place new until_at (can't know the date to run with new config.**
+
 - **endpoint** SOAP endpoint URL for your account (string, required)
 - **wsdl** SOAP endpoint URL for your account (string, default: endpoint + "?WSDL")
 - **user_id** Your user id (string, reqiured)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Below parameters are shown in "Admin" > "Web Services" page in Marketo.
 - **wsdl** SOAP endpoint URL for your account (string, default: endpoint + "?WSDL")
 - **user_id** Your user id (string, reqiured)
 - **encryption_key** Your encryption key (string, reqiured)
-- **last_updated_at** Limit datetime that a lead has been updated (this plugin fetches leads updated after this datetime) (string, required)
+- **since_at** Fetch leads since this time (string, required)
+- **until_at** Fetch leads until this time (string, default: Time.now)
 
 ### Selecting plugin type
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Below parameters are shown in "Admin" > "Web Services" page in Marketo.
 - **wsdl** SOAP endpoint URL for your account (string, default: endpoint + "?WSDL")
 - **user_id** Your user id (string, reqiured)
 - **encryption_key** Your encryption key (string, reqiured)
-- **since_at** Fetch leads since this time (string, required)
+- **from_datetime** Fetch leads since this time (string, required)
 - **until_at** Fetch leads until this time (string, default: Time.now)
 
 ### market/activity_log
@@ -69,7 +69,7 @@ in:
   wsdl: https://wsdl-url.mktoapi.com/?WSDL
   user_id: user_ABC123
   encryption_key: TOPSECRET
-  since_at: "2015-06-30"
+  from_datetime: "2015-06-30"
 out:
   type: stdout
 ```

--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ Below parameters are shown in "Admin" > "Web Services" page in Marketo.
 
 ### market/lead
 
-**NOTE: If you use feature of scheduled execution (resume) with marketo/read, you should not specify until\_at because this plugin can't place new until_at (can't know the date to run with new config.**
+**NOTE: If you use feature of scheduled execution (resume) with marketo/read, you should not specify until\_at because this plugin can't place new to_datetime (can't know the date to run with new config.**
 
 - **endpoint** SOAP endpoint URL for your account (string, required)
 - **wsdl** SOAP endpoint URL for your account (string, default: endpoint + "?WSDL")
 - **user_id** Your user id (string, reqiured)
 - **encryption_key** Your encryption key (string, reqiured)
 - **from_datetime** Fetch leads since this time (string, required)
-- **until_at** Fetch leads until this time (string, default: Time.now)
+- **to_datetime** Fetch leads until this time (string, default: Time.now)
 
 ### market/activity_log
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This plugin uses Marketo SOAP API.
 Required Embulk version >= 0.6.13.
 
 * **Plugin type**: input
-* **Resume supported**: no
+* **Resume supported**: yes for `marketo/lead`, no for `marketo/activity_log`
 * **Cleanup supported**: no
 * **Guess supported**: yes
 
@@ -34,12 +34,22 @@ $ embulk gem install embulk-input-marketo
 
 Below parameters are shown in "Admin" > "Web Services" page in Marketo.
 
+### market/lead
+
 - **endpoint** SOAP endpoint URL for your account (string, required)
 - **wsdl** SOAP endpoint URL for your account (string, default: endpoint + "?WSDL")
 - **user_id** Your user id (string, reqiured)
 - **encryption_key** Your encryption key (string, reqiured)
 - **since_at** Fetch leads since this time (string, required)
 - **until_at** Fetch leads until this time (string, default: Time.now)
+
+### market/activity_log
+
+- **endpoint** SOAP endpoint URL for your account (string, required)
+- **wsdl** SOAP endpoint URL for your account (string, default: endpoint + "?WSDL")
+- **user_id** Your user id (string, reqiured)
+- **encryption_key** Your encryption key (string, reqiured)
+- **last_updated_at** Limit datetime that a lead has been updated (this plugin fetches leads updated after this datetime) (string, required)
 
 ### Selecting plugin type
 
@@ -57,7 +67,7 @@ in:
   wsdl: https://wsdl-url.mktoapi.com/?WSDL
   user_id: user_ABC123
   encryption_key: TOPSECRET
-  last_updated_at: "2015-06-30"
+  since_at: "2015-06-30"
 out:
   type: stdout
 ```

--- a/lib/embulk/input/marketo/base.rb
+++ b/lib/embulk/input/marketo/base.rb
@@ -1,3 +1,4 @@
+require "embulk/input/marketo/timeslice"
 require "embulk/input/marketo_api"
 
 module Embulk

--- a/lib/embulk/input/marketo/base.rb
+++ b/lib/embulk/input/marketo/base.rb
@@ -6,6 +6,8 @@ module Embulk
       class Base < InputPlugin
         PREVIEW_COUNT = 15
 
+        attr_reader :soap
+
         def self.target
           raise NotImplementedError
         end

--- a/lib/embulk/input/marketo/lead.rb
+++ b/lib/embulk/input/marketo/lead.rb
@@ -85,7 +85,10 @@ module Embulk
           count = 0
           since_at = task[:since_at]
           until_at = task[:until_at]
-          @soap.each(since_at, until_at) do |lead|
+          options = {}
+          options[:batch_size] = PREVIEW_COUNT if preview?
+
+          @soap.each(since_at, until_at, options) do |lead|
             values = @columns.map do |column|
               name = column["name"].to_s
               (lead[name] || {})[:value]

--- a/lib/embulk/input/marketo/lead.rb
+++ b/lib/embulk/input/marketo/lead.rb
@@ -45,12 +45,12 @@ module Embulk
 
         def run
           count = 0
-          since_at = task[:since_at]
+          from_datetime = task[:from_datetime]
           until_at = task[:until_at]
           options = {}
           options[:batch_size] = PREVIEW_COUNT if preview?
 
-          soap.each(since_at, until_at, options) do |lead|
+          soap.each(from_datetime, until_at, options) do |lead|
             values = @columns.map do |column|
               name = column["name"].to_s
               (lead[name] || {})[:value]
@@ -64,7 +64,7 @@ module Embulk
 
           page_builder.finish
 
-          commit_report = {since_at: until_at}
+          commit_report = {from_datetime: until_at}
           return commit_report
         end
       end

--- a/lib/embulk/input/marketo/lead.rb
+++ b/lib/embulk/input/marketo/lead.rb
@@ -4,52 +4,14 @@ module Embulk
   module Input
     module Marketo
       class Lead < Base
+        include Timeslice
+
         PREVIEW_COUNT = 15
 
         Plugin.register_input("marketo/lead", self)
 
         def self.target
           :lead
-        end
-
-        def self.transaction(config, &control)
-          endpoint_url = config.param(:endpoint, :string)
-
-          if config.param(:last_updated_at, :string, default: nil)
-            Embulk.logger.warn "config: last_updated_at is deprecated. Use since_at/until_at"
-          end
-
-          task = {
-            endpoint_url: endpoint_url,
-            wsdl_url: config.param(:wsdl, :string, default: "#{endpoint_url}?WSDL"),
-            user_id: config.param(:user_id, :string),
-            encryption_key: config.param(:encryption_key, :string),
-            since_at: config.param(:since_at, :string),
-            until_at: config.param(:until_at, :string, default: Time.now.to_s),
-            columns: config.param(:columns, :array)
-          }
-
-          columns = []
-
-          task[:columns].each do |column|
-            name = column["name"]
-            type = column["type"].to_sym
-
-            columns << Column.new(nil, name, type, column["format"])
-          end
-
-          resume(task, columns, 1, &control)
-        end
-
-        def self.guess(config)
-          if config.param(:last_updated_at, :string, default: nil)
-            Embulk.logger.warn "config: last_updated_at is deprecated. Use since_at/until_at"
-          end
-
-          client = soap_client(config)
-          metadata = client.metadata
-
-          return {"columns" => generate_columns(metadata)}
         end
 
         def self.generate_columns(metadata)

--- a/lib/embulk/input/marketo/lead.rb
+++ b/lib/embulk/input/marketo/lead.rb
@@ -88,7 +88,7 @@ module Embulk
           options = {}
           options[:batch_size] = PREVIEW_COUNT if preview?
 
-          @soap.each(since_at, until_at, options) do |lead|
+          soap.each(since_at, until_at, options) do |lead|
             values = @columns.map do |column|
               name = column["name"].to_s
               (lead[name] || {})[:value]

--- a/lib/embulk/input/marketo/lead.rb
+++ b/lib/embulk/input/marketo/lead.rb
@@ -46,11 +46,11 @@ module Embulk
         def run
           count = 0
           from_datetime = task[:from_datetime]
-          until_at = task[:until_at]
+          to_datetime = task[:to_datetime]
           options = {}
           options[:batch_size] = PREVIEW_COUNT if preview?
 
-          soap.each(from_datetime, until_at, options) do |lead|
+          soap.each(from_datetime, to_datetime, options) do |lead|
             values = @columns.map do |column|
               name = column["name"].to_s
               (lead[name] || {})[:value]
@@ -64,7 +64,7 @@ module Embulk
 
           page_builder.finish
 
-          commit_report = {from_datetime: until_at}
+          commit_report = {from_datetime: to_datetime}
           return commit_report
         end
       end

--- a/lib/embulk/input/marketo/timeslice.rb
+++ b/lib/embulk/input/marketo/timeslice.rb
@@ -1,0 +1,53 @@
+module Embulk
+  module Input
+    module Marketo
+      module Timeslice
+        def self.included(klass)
+          klass.extend ClassMethods
+        end
+
+        module ClassMethods
+          def guess(config)
+            if config.param(:last_updated_at, :string, default: nil)
+              Embulk.logger.warn "config: last_updated_at is deprecated. Use since_at/until_at"
+            end
+
+            client = soap_client(config)
+            metadata = client.metadata
+
+            return {"columns" => generate_columns(metadata)}
+          end
+
+          def transaction(config, &control)
+            endpoint_url = config.param(:endpoint, :string)
+
+            if config.param(:last_updated_at, :string, default: nil)
+              Embulk.logger.warn "config: last_updated_at is deprecated. Use since_at/until_at"
+            end
+
+            task = {
+              endpoint_url: endpoint_url,
+              wsdl_url: config.param(:wsdl, :string, default: "#{endpoint_url}?WSDL"),
+              user_id: config.param(:user_id, :string),
+              encryption_key: config.param(:encryption_key, :string),
+              since_at: config.param(:since_at, :string),
+              until_at: config.param(:until_at, :string, default: Time.now.to_s),
+              columns: config.param(:columns, :array)
+            }
+
+            columns = []
+
+            task[:columns].each do |column|
+              name = column["name"]
+              type = column["type"].to_sym
+
+              columns << Column.new(nil, name, type, column["format"])
+            end
+
+            resume(task, columns, 1, &control)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/embulk/input/marketo/timeslice.rb
+++ b/lib/embulk/input/marketo/timeslice.rb
@@ -9,7 +9,7 @@ module Embulk
         module ClassMethods
           def guess(config)
             if config.param(:last_updated_at, :string, default: nil)
-              Embulk.logger.warn "config: last_updated_at is deprecated. Use since_at/until_at"
+              Embulk.logger.warn "config: last_updated_at is deprecated. Use from_datetime/until_at"
             end
 
             client = soap_client(config)
@@ -22,14 +22,14 @@ module Embulk
             endpoint_url = config.param(:endpoint, :string)
 
             if config.param(:last_updated_at, :string, default: nil)
-              Embulk.logger.warn "config: last_updated_at is deprecated. Use since_at/until_at"
+              Embulk.logger.warn "config: last_updated_at is deprecated. Use from_datetime/until_at"
             end
 
-            since_at = config.param(:since_at, :string)
+            from_datetime = config.param(:from_datetime, :string)
             until_at = config.param(:until_at, :string, default: Time.now.to_s)
 
-            if Time.parse(since_at) > Time.parse(until_at)
-              raise ConfigError, "config: since_at '#{since_at}' is later than '#{until_at}'."
+            if Time.parse(from_datetime) > Time.parse(until_at)
+              raise ConfigError, "config: from_datetime '#{from_datetime}' is later than '#{until_at}'."
             end
 
             task = {
@@ -37,7 +37,7 @@ module Embulk
               wsdl_url: config.param(:wsdl, :string, default: "#{endpoint_url}?WSDL"),
               user_id: config.param(:user_id, :string),
               encryption_key: config.param(:encryption_key, :string),
-              since_at: since_at,
+              from_datetime: from_datetime,
               until_at: until_at,
               columns: config.param(:columns, :array)
             }

--- a/lib/embulk/input/marketo/timeslice.rb
+++ b/lib/embulk/input/marketo/timeslice.rb
@@ -25,13 +25,20 @@ module Embulk
               Embulk.logger.warn "config: last_updated_at is deprecated. Use since_at/until_at"
             end
 
+            since_at = config.param(:since_at, :string)
+            until_at = config.param(:until_at, :string, default: Time.now.to_s)
+
+            if Time.parse(since_at) > Time.parse(until_at)
+              raise ConfigError, "config: since_at '#{since_at}' is later than '#{until_at}'."
+            end
+
             task = {
               endpoint_url: endpoint_url,
               wsdl_url: config.param(:wsdl, :string, default: "#{endpoint_url}?WSDL"),
               user_id: config.param(:user_id, :string),
               encryption_key: config.param(:encryption_key, :string),
-              since_at: config.param(:since_at, :string),
-              until_at: config.param(:until_at, :string, default: Time.now.to_s),
+              since_at: since_at,
+              until_at: until_at,
               columns: config.param(:columns, :array)
             }
 

--- a/lib/embulk/input/marketo/timeslice.rb
+++ b/lib/embulk/input/marketo/timeslice.rb
@@ -9,7 +9,7 @@ module Embulk
         module ClassMethods
           def guess(config)
             if config.param(:last_updated_at, :string, default: nil)
-              Embulk.logger.warn "config: last_updated_at is deprecated. Use from_datetime/until_at"
+              Embulk.logger.warn "config: last_updated_at is deprecated. Use from_datetime/to_datetime"
             end
 
             client = soap_client(config)
@@ -22,14 +22,14 @@ module Embulk
             endpoint_url = config.param(:endpoint, :string)
 
             if config.param(:last_updated_at, :string, default: nil)
-              Embulk.logger.warn "config: last_updated_at is deprecated. Use from_datetime/until_at"
+              Embulk.logger.warn "config: last_updated_at is deprecated. Use from_datetime/to_datetime"
             end
 
             from_datetime = config.param(:from_datetime, :string)
-            until_at = config.param(:until_at, :string, default: Time.now.to_s)
+            to_datetime = config.param(:to_datetime, :string, default: Time.now.to_s)
 
-            if Time.parse(from_datetime) > Time.parse(until_at)
-              raise ConfigError, "config: from_datetime '#{from_datetime}' is later than '#{until_at}'."
+            if Time.parse(from_datetime) > Time.parse(to_datetime)
+              raise ConfigError, "config: from_datetime '#{from_datetime}' is later than '#{to_datetime}'."
             end
 
             task = {
@@ -38,7 +38,7 @@ module Embulk
               user_id: config.param(:user_id, :string),
               encryption_key: config.param(:encryption_key, :string),
               from_datetime: from_datetime,
-              until_at: until_at,
+              to_datetime: to_datetime,
               columns: config.param(:columns, :array)
             }
 

--- a/lib/embulk/input/marketo_api/soap/base.rb
+++ b/lib/embulk/input/marketo_api/soap/base.rb
@@ -1,4 +1,5 @@
 require "savon"
+require "embulk/input/marketo_api/soap/timeslice"
 
 module Embulk
   module Input
@@ -53,39 +54,6 @@ module Embulk
               'requestTimestamp' => timestamp,
               'requestSignature' => hashed_signature.to_s
             }
-          end
-
-          def generate_time_range(from, to = nil)
-            # e.g. from = 2010-01-01 15:00, to = 2010-01-03 09:30
-            # convert to such array:
-            # [
-            #   {from: 2010-01-01 15:00, to: 2010-01-01 16:00},
-            #   {from: 2010-01-01 16:00, to: 2010-01-01 17:00},
-            #   ...
-            #   {from: 2010-01-03 08:00, to: 2010-01-03 09:00},
-            #   {from: 2010-01-03 09:00, to: 2010-01-03 09:30},
-            # ]
-            # to fetch data from Marketo API with each day as
-            # desribed on official blog:
-            # http://developers.marketo.com/blog/performance-tuning-api-requests/
-            to ||= Time.now
-            from = Time.parse(from) unless from.is_a?(Time)
-            to = Time.parse(to) unless to.is_a?(Time)
-
-            result = []
-            since = from
-            while since < to
-              next_since = since + 3600
-              if to < next_since
-                next_since = to
-              end
-              result << {
-                from: since,
-                to: next_since
-              }
-              since = next_since
-            end
-            result
           end
 
           def catch_unretryable_error(&block)

--- a/lib/embulk/input/marketo_api/soap/base.rb
+++ b/lib/embulk/input/marketo_api/soap/base.rb
@@ -55,6 +55,39 @@ module Embulk
             }
           end
 
+          def generate_time_range(from, to = nil)
+            # e.g. from = 2010-01-01 15:00, to = 2010-01-03 09:30
+            # convert to such array:
+            # [
+            #   {from: 2010-01-01 15:00, to: 2010-01-01 16:00},
+            #   {from: 2010-01-01 16:00, to: 2010-01-01 17:00},
+            #   ...
+            #   {from: 2010-01-03 08:00, to: 2010-01-03 09:00},
+            #   {from: 2010-01-03 09:00, to: 2010-01-03 09:30},
+            # ]
+            # to fetch data from Marketo API with each day as
+            # desribed on official blog:
+            # http://developers.marketo.com/blog/performance-tuning-api-requests/
+            to ||= Time.now
+            from = Time.parse(from) unless from.is_a?(Time)
+            to = Time.parse(to) unless to.is_a?(Time)
+
+            result = []
+            since = from
+            while since < to
+              next_since = since + 3600
+              if to < next_since
+                next_since = to
+              end
+              result << {
+                from: since,
+                to: next_since
+              }
+              since = next_since
+            end
+            result
+          end
+
           def catch_unretryable_error(&block)
             yield
           rescue Savon::SOAPFault => e

--- a/lib/embulk/input/marketo_api/soap/lead.rb
+++ b/lib/embulk/input/marketo_api/soap/lead.rb
@@ -16,6 +16,7 @@ module Embulk
           end
 
           def each(since_at, until_at = nil, options = {}, &block)
+            # http://developers.marketo.com/documentation/soap/getmultipleleads/
             until_at ||= Time.now
 
             generate_time_range(since_at, until_at).each do |range|

--- a/lib/embulk/input/marketo_api/soap/lead.rb
+++ b/lib/embulk/input/marketo_api/soap/lead.rb
@@ -5,6 +5,8 @@ module Embulk
     module MarketoApi
       module Soap
         class Lead < Base
+          include Timeslice
+
           # NOTE: batch_size is allowed at 1000, but that takes 2 minutes in 1 request.
           #       We use 250 for the default (about 30 seconds)
           BATCH_SIZE_DEFAULT = 250

--- a/lib/embulk/input/marketo_api/soap/lead.rb
+++ b/lib/embulk/input/marketo_api/soap/lead.rb
@@ -32,7 +32,7 @@ module Embulk
                 },
                 batch_size: options[:batch_size] || BATCH_SIZE_DEFAULT,
               }
-              Embulk.logger.info "fetching '#{range[:from]}' to '#{range[:to]}'"
+              Embulk.logger.info "Fetching from '#{range[:from]}' to '#{range[:to]}'..."
 
               stream_position = fetch(request, &block)
 

--- a/lib/embulk/input/marketo_api/soap/lead.rb
+++ b/lib/embulk/input/marketo_api/soap/lead.rb
@@ -17,7 +17,7 @@ module Embulk
             response.body[:success_describe_m_object][:result][:metadata][:field_list][:field]
           end
 
-          def each(since_at, until_at = nil, options = {}, &block)
+          def each(since_at, until_at, options = {}, &block)
             # http://developers.marketo.com/documentation/soap/getmultipleleads/
             until_at ||= Time.now
 

--- a/lib/embulk/input/marketo_api/soap/lead.rb
+++ b/lib/embulk/input/marketo_api/soap/lead.rb
@@ -25,7 +25,7 @@ module Embulk
               attributes!: {
                 lead_selector: {"xsi:type" => "ns1:LastUpdateAtSelector"}
               },
-              batch_size: 1000,
+              batch_size: 250,
             }
 
             stream_position = fetch(request, &block)

--- a/lib/embulk/input/marketo_api/soap/lead.rb
+++ b/lib/embulk/input/marketo_api/soap/lead.rb
@@ -11,34 +11,57 @@ module Embulk
             response.body[:success_describe_m_object][:result][:metadata][:field_list][:field]
           end
 
-          def each(last_updated_at, &block)
-            # http://developers.marketo.com/documentation/soap/getmultipleleads/
+          def each(since_at = nil, until_at = nil, &block)
+            since_at ||= get_oldest_data
+            until_at ||= Time.now
 
-            last_updated_at = Time.parse(last_updated_at).iso8601
+            generate_time_range(since_at, until_at).each do |range|
+              request = {
+                lead_selector: {
+                  oldest_updated_at: range[:from].iso8601,
+                  latest_updated_at: range[:to].iso8601,
+                },
+                attributes!: {
+                  lead_selector: {"xsi:type" => "ns1:LastUpdateAtSelector"}
+                },
+                batch_size: 250,
+              }
+              Embulk.logger.info "fetching '#{range[:from]}' to '#{range[:to]}'"
 
-            # TODO: generate request in #fetch
-            # TODO: use PREVIEW_COUNT as batch_size in preview
-            request = {
-              lead_selector: {
-                oldest_updated_at: last_updated_at,
-              },
-              attributes!: {
-                lead_selector: {"xsi:type" => "ns1:LastUpdateAtSelector"}
-              },
-              batch_size: 250,
-            }
+              stream_position = fetch(request, &block)
 
-            stream_position = fetch(request, &block)
-
-            while stream_position
-              stream_position = fetch(request.merge(stream_position: stream_position), &block)
+              while stream_position
+                stream_position = fetch(request.merge(stream_position: stream_position), &block)
+              end
             end
           end
 
           private
 
+          def get_oldest_data
+            Time.parse("2010-01-01") # NOTE: return fixed date currently, see below NOTE
+
+            # NOTE: below code will timeout (over 300 seconds)
+            #       if we want to detect oldest lead from API, we should find other way
+            #
+            # request = {
+            #   lead_selector: {
+            #     oldest_updated_at: Time.parse("2010-01-01").iso8601,
+            #   },
+            #   attributes!: {
+            #     lead_selector: {"xsi:type" => "ns1:LastUpdateAtSelector"}
+            #   },
+            #   batch_size: 1,
+            # }
+            # fetch(request) do |lead|
+            #   p lead
+            # end
+          end
+
           def fetch(request = {}, &block)
+            start = Time.now
             response = savon_call(:get_multiple_leads, message: request)
+            Embulk.logger.info "fetched in #{Time.now - start} seconds"
 
             remaining = response.xpath('//remainingCount').text.to_i
             Embulk.logger.info "Remaining records: #{remaining}"

--- a/lib/embulk/input/marketo_api/soap/lead.rb
+++ b/lib/embulk/input/marketo_api/soap/lead.rb
@@ -17,11 +17,11 @@ module Embulk
             response.body[:success_describe_m_object][:result][:metadata][:field_list][:field]
           end
 
-          def each(since_at, until_at, options = {}, &block)
+          def each(from_datetime, until_at, options = {}, &block)
             # http://developers.marketo.com/documentation/soap/getmultipleleads/
             until_at ||= Time.now
 
-            generate_time_range(since_at, until_at).each do |range|
+            generate_time_range(from_datetime, until_at).each do |range|
               request = {
                 lead_selector: {
                   oldest_updated_at: range[:from].iso8601,

--- a/lib/embulk/input/marketo_api/soap/lead.rb
+++ b/lib/embulk/input/marketo_api/soap/lead.rb
@@ -15,8 +15,7 @@ module Embulk
             response.body[:success_describe_m_object][:result][:metadata][:field_list][:field]
           end
 
-          def each(since_at = nil, until_at = nil, &block)
-            since_at ||= get_oldest_data
+          def each(since_at, until_at = nil, &block)
             until_at ||= Time.now
 
             generate_time_range(since_at, until_at).each do |range|
@@ -41,26 +40,6 @@ module Embulk
           end
 
           private
-
-          def get_oldest_data
-            Time.parse("2010-01-01") # NOTE: return fixed date currently, see below NOTE
-
-            # NOTE: below code will timeout (over 300 seconds)
-            #       if we want to detect oldest lead from API, we should find other way
-            #
-            # request = {
-            #   lead_selector: {
-            #     oldest_updated_at: Time.parse("2010-01-01").iso8601,
-            #   },
-            #   attributes!: {
-            #     lead_selector: {"xsi:type" => "ns1:LastUpdateAtSelector"}
-            #   },
-            #   batch_size: 1,
-            # }
-            # fetch(request) do |lead|
-            #   p lead
-            # end
-          end
 
           def fetch(request = {}, &block)
             start = Time.now

--- a/lib/embulk/input/marketo_api/soap/lead.rb
+++ b/lib/embulk/input/marketo_api/soap/lead.rb
@@ -17,11 +17,11 @@ module Embulk
             response.body[:success_describe_m_object][:result][:metadata][:field_list][:field]
           end
 
-          def each(from_datetime, until_at, options = {}, &block)
+          def each(from_datetime, to_datetime, options = {}, &block)
             # http://developers.marketo.com/documentation/soap/getmultipleleads/
-            until_at ||= Time.now
+            to_datetime ||= Time.now
 
-            generate_time_range(from_datetime, until_at).each do |range|
+            generate_time_range(from_datetime, to_datetime).each do |range|
               request = {
                 lead_selector: {
                   oldest_updated_at: range[:from].iso8601,

--- a/lib/embulk/input/marketo_api/soap/lead.rb
+++ b/lib/embulk/input/marketo_api/soap/lead.rb
@@ -47,7 +47,7 @@ module Embulk
           def fetch(request = {}, &block)
             start = Time.now
             response = savon_call(:get_multiple_leads, message: request)
-            Embulk.logger.info "fetched in #{Time.now - start} seconds"
+            Embulk.logger.info "Fetched in #{Time.now - start} seconds"
 
             records = response.xpath('//leadRecordList/leadRecord')
             remaining = response.xpath('//remainingCount').text.to_i

--- a/lib/embulk/input/marketo_api/soap/lead.rb
+++ b/lib/embulk/input/marketo_api/soap/lead.rb
@@ -49,9 +49,11 @@ module Embulk
             response = savon_call(:get_multiple_leads, message: request)
             Embulk.logger.info "fetched in #{Time.now - start} seconds"
 
+            records = response.xpath('//leadRecordList/leadRecord')
             remaining = response.xpath('//remainingCount').text.to_i
-            Embulk.logger.info "Remaining records: #{remaining}"
-            response.xpath('//leadRecordList/leadRecord').each do |lead|
+            Embulk.logger.info "Fetched records in the range: #{records.size}"
+            Embulk.logger.info "Remaining records in the range: #{remaining}"
+            records.each do |lead|
               record = {
                 "id" => {type: :integer, value: lead.xpath('Id').text.to_i},
                 "email" => {type: :string, value: lead.xpath('Email').text}

--- a/lib/embulk/input/marketo_api/soap/lead.rb
+++ b/lib/embulk/input/marketo_api/soap/lead.rb
@@ -15,7 +15,7 @@ module Embulk
             response.body[:success_describe_m_object][:result][:metadata][:field_list][:field]
           end
 
-          def each(since_at, until_at = nil, &block)
+          def each(since_at, until_at = nil, options = {}, &block)
             until_at ||= Time.now
 
             generate_time_range(since_at, until_at).each do |range|
@@ -27,7 +27,7 @@ module Embulk
                 attributes!: {
                   lead_selector: {"xsi:type" => "ns1:LastUpdateAtSelector"}
                 },
-                batch_size: BATCH_SIZE_DEFAULT,
+                batch_size: options[:batch_size] || BATCH_SIZE_DEFAULT,
               }
               Embulk.logger.info "fetching '#{range[:from]}' to '#{range[:to]}'"
 

--- a/lib/embulk/input/marketo_api/soap/lead.rb
+++ b/lib/embulk/input/marketo_api/soap/lead.rb
@@ -5,6 +5,10 @@ module Embulk
     module MarketoApi
       module Soap
         class Lead < Base
+          # NOTE: batch_size is allowed at 1000, but that takes 2 minutes in 1 request.
+          #       We use 250 for the default (about 30 seconds)
+          BATCH_SIZE_DEFAULT = 250
+
           def metadata
             # http://developers.marketo.com/documentation/soap/describemobject/
             response = savon_call(:describe_m_object, message: {object_name: "LeadRecord"})
@@ -24,7 +28,7 @@ module Embulk
                 attributes!: {
                   lead_selector: {"xsi:type" => "ns1:LastUpdateAtSelector"}
                 },
-                batch_size: 250,
+                batch_size: BATCH_SIZE_DEFAULT,
               }
               Embulk.logger.info "fetching '#{range[:from]}' to '#{range[:to]}'"
 

--- a/lib/embulk/input/marketo_api/soap/timeslice.rb
+++ b/lib/embulk/input/marketo_api/soap/timeslice.rb
@@ -1,0 +1,44 @@
+module Embulk
+  module Input
+    module MarketoApi
+      module Soap
+        module Timeslice
+          private
+
+          def generate_time_range(from, to = nil)
+            # e.g. from = 2010-01-01 15:00, to = 2010-01-03 09:30
+            # convert to such array:
+            # [
+            #   {from: 2010-01-01 15:00, to: 2010-01-01 16:00},
+            #   {from: 2010-01-01 16:00, to: 2010-01-01 17:00},
+            #   ...
+            #   {from: 2010-01-03 08:00, to: 2010-01-03 09:00},
+            #   {from: 2010-01-03 09:00, to: 2010-01-03 09:30},
+            # ]
+            # to fetch data from Marketo API with each day as
+            # desribed on official blog:
+            # http://developers.marketo.com/blog/performance-tuning-api-requests/
+            to ||= Time.now
+            from = Time.parse(from) unless from.is_a?(Time)
+            to = Time.parse(to) unless to.is_a?(Time)
+
+            result = []
+            since = from
+            while since < to
+              next_since = since + 3600
+              if to < next_since
+                next_since = to
+              end
+              result << {
+                from: since,
+                to: next_since
+              }
+              since = next_since
+            end
+            result
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/embulk/input/marketo_api/soap/timeslice.rb
+++ b/lib/embulk/input/marketo_api/soap/timeslice.rb
@@ -5,7 +5,7 @@ module Embulk
         module Timeslice
           private
 
-          def generate_time_range(from, to = nil)
+          def generate_time_range(from, to)
             # e.g. from = 2010-01-01 15:00, to = 2010-01-03 09:30
             # convert to such array:
             # [

--- a/test/embulk/input/marketo/test_lead.rb
+++ b/test/embulk/input/marketo/test_lead.rb
@@ -186,10 +186,6 @@ module Embulk
           }
         end
 
-        def last_updated_at
-          "2015-07-01 00:00:00+00:00"
-        end
-
         def since_at
           "2015-07-01 00:00:00+00:00"
         end

--- a/test/embulk/input/marketo/test_lead.rb
+++ b/test/embulk/input/marketo/test_lead.rb
@@ -26,6 +26,27 @@ module Embulk
           mute_logger
         end
 
+        def test_invalid_since_at_until_at
+          control = proc {} # dummy
+
+          settings = {
+            endpoint: "https://marketo.example.com",
+            wsdl: "https://marketo.example.com/?wsdl",
+            user_id: "user_id",
+            encryption_key: "TOPSECRET",
+            columns: [
+              {"name" => "Name", "type" => "string"},
+            ],
+            since_at: Time.now + 3600,
+            until_at: Time.now,
+          }
+          config = DataSource[settings.to_a]
+
+          assert_raise(ConfigError) do
+            Lead.transaction(config, &control)
+          end
+        end
+
         class RunTest < self
           def setup
             setup_soap

--- a/test/embulk/input/marketo/test_lead.rb
+++ b/test/embulk/input/marketo/test_lead.rb
@@ -26,7 +26,7 @@ module Embulk
           mute_logger
         end
 
-        def test_invalid_since_at_until_at
+        def test_invalid_from_datetime_until_at
           control = proc {} # dummy
 
           settings = {
@@ -37,7 +37,7 @@ module Embulk
             columns: [
               {"name" => "Name", "type" => "string"},
             ],
-            since_at: Time.now + 3600,
+            from_datetime: Time.now + 3600,
             until_at: Time.now,
           }
           config = DataSource[settings.to_a]
@@ -80,7 +80,7 @@ module Embulk
             stub(@plugin.soap).each { }
 
             commit_report = @plugin.run
-            assert_equal until_at, commit_report[:since_at]
+            assert_equal until_at, commit_report[:from_datetime]
           end
 
           def test_preview_through
@@ -208,7 +208,7 @@ module Embulk
             wsdl: "https://marketo.example.com/?wsdl",
             user_id: "user_id",
             encryption_key: "TOPSECRET",
-            since_at: since_at,
+            from_datetime: from_datetime,
             until_at: until_at,
             columns: [
               {"name" => "Name", "type" => "string"},
@@ -216,7 +216,7 @@ module Embulk
           }
         end
 
-        def since_at
+        def from_datetime
           "2015-07-01 00:00:00+00:00"
         end
 
@@ -226,7 +226,7 @@ module Embulk
 
         def timerange
           soap = MarketoApi::Soap::Lead.new(settings[:endpoint], settings[:wsdl], settings[:user_id], settings[:encryption_key])
-          soap.send(:generate_time_range, since_at, until_at)
+          soap.send(:generate_time_range, from_datetime, until_at)
         end
 
         def task
@@ -235,7 +235,7 @@ module Embulk
             wsdl_url: "https://marketo.example.com/?wsdl",
             user_id: "user_id",
             encryption_key: "TOPSECRET",
-            since_at: since_at,
+            from_datetime: from_datetime,
             until_at: until_at,
             columns: [
               {"name" => "Name", "type" => "string"},

--- a/test/embulk/input/marketo/test_lead.rb
+++ b/test/embulk/input/marketo/test_lead.rb
@@ -53,6 +53,15 @@ module Embulk
             @plugin.run
           end
 
+          def test_run_commit_report
+            # do not requests
+            stub(@page_builder).finish
+            stub(@plugin.soap).each { }
+
+            commit_report = @plugin.run
+            assert_equal until_at, commit_report[:since_at]
+          end
+
           def test_preview_through
             stub(@plugin).preview? { true }
 

--- a/test/embulk/input/marketo/test_lead.rb
+++ b/test/embulk/input/marketo/test_lead.rb
@@ -26,7 +26,7 @@ module Embulk
           mute_logger
         end
 
-        def test_invalid_from_datetime_until_at
+        def test_invalid_from_datetime_to_datetime
           control = proc {} # dummy
 
           settings = {
@@ -38,7 +38,7 @@ module Embulk
               {"name" => "Name", "type" => "string"},
             ],
             from_datetime: Time.now + 3600,
-            until_at: Time.now,
+            to_datetime: Time.now,
           }
           config = DataSource[settings.to_a]
 
@@ -80,7 +80,7 @@ module Embulk
             stub(@plugin.soap).each { }
 
             commit_report = @plugin.run
-            assert_equal until_at, commit_report[:from_datetime]
+            assert_equal to_datetime, commit_report[:from_datetime]
           end
 
           def test_preview_through
@@ -209,7 +209,7 @@ module Embulk
             user_id: "user_id",
             encryption_key: "TOPSECRET",
             from_datetime: from_datetime,
-            until_at: until_at,
+            to_datetime: to_datetime,
             columns: [
               {"name" => "Name", "type" => "string"},
             ]
@@ -220,13 +220,13 @@ module Embulk
           "2015-07-01 00:00:00+00:00"
         end
 
-        def until_at
+        def to_datetime
           "2015-07-01 00:00:05+00:00"
         end
 
         def timerange
           soap = MarketoApi::Soap::Lead.new(settings[:endpoint], settings[:wsdl], settings[:user_id], settings[:encryption_key])
-          soap.send(:generate_time_range, from_datetime, until_at)
+          soap.send(:generate_time_range, from_datetime, to_datetime)
         end
 
         def task
@@ -236,7 +236,7 @@ module Embulk
             user_id: "user_id",
             encryption_key: "TOPSECRET",
             from_datetime: from_datetime,
-            until_at: until_at,
+            to_datetime: to_datetime,
             columns: [
               {"name" => "Name", "type" => "string"},
             ]

--- a/test/embulk/input/marketo/test_lead.rb
+++ b/test/embulk/input/marketo/test_lead.rb
@@ -57,7 +57,7 @@ module Embulk
             stub(@plugin).preview? { true }
 
             any_instance_of(Savon::Client) do |klass|
-              mock(klass).call(:get_multiple_leads, message: request) do
+              mock(klass).call(:get_multiple_leads, message: request.merge(batch_size: Lead::PREVIEW_COUNT)) do
                 preview_leads_response
               end
             end

--- a/test/embulk/input/marketo_api/soap/test_lead.rb
+++ b/test/embulk/input/marketo_api/soap/test_lead.rb
@@ -23,15 +23,6 @@ module Embulk
               since_at = "2015-07-06"
               timerange = soap.send(:generate_time_range, since_at)
 
-              request = {
-                lead_selector: {
-                  oldest_updated_at: timerange.first[:from].iso8601,
-                  latest_updated_at: timerange.first[:to].iso8601,
-                },
-                attributes!: {lead_selector: {"xsi:type"=>"ns1:LastUpdateAtSelector"}},
-                batch_size: Lead::BATCH_SIZE_DEFAULT,
-              }
-
               stub(soap).fetch { nil }
               mock(soap).fetch(anything).times(timerange.length)
 

--- a/test/embulk/input/marketo_api/soap/test_lead.rb
+++ b/test/embulk/input/marketo_api/soap/test_lead.rb
@@ -21,19 +21,19 @@ module Embulk
 
             def test_each_invoke_fetch
               from_datetime = "2015-07-06"
-              until_at = "2015-07-07"
-              timerange = soap.send(:generate_time_range, from_datetime, until_at)
+              to_datetime = "2015-07-07"
+              timerange = soap.send(:generate_time_range, from_datetime, to_datetime)
 
               stub(soap).fetch { nil }
               mock(soap).fetch(anything).times(timerange.length)
 
-              soap.each(from_datetime, until_at) { }
+              soap.each(from_datetime, to_datetime) { }
             end
 
             def test_each_invoke_fetch_with_specified_time
               from_datetime = "2015-07-06"
-              until_at = "2015-07-07"
-              timerange = soap.send(:generate_time_range, from_datetime, until_at)
+              to_datetime = "2015-07-07"
+              timerange = soap.send(:generate_time_range, from_datetime, to_datetime)
 
               request = {
                 lead_selector: {
@@ -47,12 +47,12 @@ module Embulk
               stub(soap).fetch { nil }
               mock(soap).fetch(request)
 
-              soap.each(from_datetime, until_at) { }
+              soap.each(from_datetime, to_datetime) { }
             end
 
             def test_each_fetch_next_page
               from_datetime = "2015-07-06 00:00:00"
-              until_at = "2015-07-06 00:00:01"
+              to_datetime = "2015-07-06 00:00:01"
 
               any_instance_of(Savon::Client) do |klass|
                 mock(klass).call(:get_multiple_leads, anything) do
@@ -64,7 +64,7 @@ module Embulk
               leads_count = next_stream_leads_response.xpath('//leadRecord').length
               mock(proc).call(anything).times(leads_count)
 
-              soap.each(from_datetime, until_at, &proc)
+              soap.each(from_datetime, to_datetime, &proc)
             end
           end
 

--- a/test/embulk/input/marketo_api/soap/test_lead.rb
+++ b/test/embulk/input/marketo_api/soap/test_lead.rb
@@ -29,7 +29,7 @@ module Embulk
                   latest_updated_at: timerange.first[:to].iso8601,
                 },
                 attributes!: {lead_selector: {"xsi:type"=>"ns1:LastUpdateAtSelector"}},
-                batch_size: 250
+                batch_size: Lead::BATCH_SIZE_DEFAULT,
               }
 
               stub(soap).fetch { nil }
@@ -48,7 +48,7 @@ module Embulk
                   latest_updated_at: timerange.first[:to].iso8601,
                 },
                 attributes!: {lead_selector: {"xsi:type"=>"ns1:LastUpdateAtSelector"}},
-                batch_size: 250
+                batch_size: Lead::BATCH_SIZE_DEFAULT,
               }
 
               stub(soap).fetch { nil }

--- a/test/embulk/input/marketo_api/soap/test_lead.rb
+++ b/test/embulk/input/marketo_api/soap/test_lead.rb
@@ -21,17 +21,19 @@ module Embulk
 
             def test_each_invoke_fetch
               since_at = "2015-07-06"
-              timerange = soap.send(:generate_time_range, since_at)
+              until_at = "2015-07-07"
+              timerange = soap.send(:generate_time_range, since_at, until_at)
 
               stub(soap).fetch { nil }
               mock(soap).fetch(anything).times(timerange.length)
 
-              soap.each(since_at) { }
+              soap.each(since_at, until_at) { }
             end
 
             def test_each_invoke_fetch_with_specified_time
               since_at = "2015-07-06"
-              timerange = soap.send(:generate_time_range, since_at)
+              until_at = "2015-07-07"
+              timerange = soap.send(:generate_time_range, since_at, until_at)
 
               request = {
                 lead_selector: {
@@ -45,7 +47,7 @@ module Embulk
               stub(soap).fetch { nil }
               mock(soap).fetch(request)
 
-              soap.each(since_at) { }
+              soap.each(since_at, until_at) { }
             end
 
             def test_each_fetch_next_page

--- a/test/embulk/input/marketo_api/soap/test_lead.rb
+++ b/test/embulk/input/marketo_api/soap/test_lead.rb
@@ -74,7 +74,6 @@ module Embulk
             data do
               {
                 "8/1 to 8/2" => ["2015-08-01 00:00:00", "2015-08-02 00:00:00", 24],
-                "from 10 minutes ago to nil(now)" => [Time.now - 600, nil, 1],
                 "over the days" => ["2015-08-01 19:00:00", "2015-08-03 05:00:00", 34],
                 "odd times" => ["2015-08-01 11:11:11", "2015-08-01 22:22:22", 12],
               }
@@ -83,6 +82,15 @@ module Embulk
               from, to, count = data
               range = soap.send(:generate_time_range, from, to)
               assert_equal count, range.length
+            end
+
+            def test_if_to_is_nil_use_time_now
+              from = "2000-01-01"
+              now = Time.now
+              stub(Time).now { now }
+
+              range = soap.send(:generate_time_range, from, nil)
+              assert_equal now, range.last[:to]
             end
           end
 

--- a/test/embulk/input/marketo_api/soap/test_lead.rb
+++ b/test/embulk/input/marketo_api/soap/test_lead.rb
@@ -1,5 +1,6 @@
 require "embulk/input/marketo_api/soap/lead"
 require "lead_fixtures"
+require "mute_logger"
 
 module Embulk
   module Input
@@ -7,32 +8,96 @@ module Embulk
       module Soap
         class LeadTest < Test::Unit::TestCase
           include LeadFixtures
+          include MuteLogger
 
-          def test_each
-            stub(Embulk).logger { ::Logger.new(IO::NULL) }
-            last_updated_at = "2015-07-06"
+          def setup
+            mute_logger
+          end
 
-            request = {
-              lead_selector: {oldest_updated_at: Time.parse(last_updated_at).iso8601},
-              attributes!: {lead_selector: {"xsi:type"=>"ns1:LastUpdateAtSelector"}},
-              batch_size: 1000
-            }
-
-            any_instance_of(Savon::Client) do |klass|
-              mock(klass).call(:get_multiple_leads, message: request) do
-                next_stream_leads_response
-              end
+          class TestEach < self
+            def setup
+              super
             end
 
-            proc = proc{ "" }
-            leads_count = next_stream_leads_response.xpath('//leadRecord').length
-            mock(proc).call(anything).times(leads_count)
+            def test_each_invoke_fetch
+              since_at = "2015-07-06"
+              timerange = soap.send(:generate_time_range, since_at)
 
-            soap.each(last_updated_at, &proc)
+              request = {
+                lead_selector: {
+                  oldest_updated_at: timerange.first[:from].iso8601,
+                  latest_updated_at: timerange.first[:to].iso8601,
+                },
+                attributes!: {lead_selector: {"xsi:type"=>"ns1:LastUpdateAtSelector"}},
+                batch_size: 250
+              }
+
+              stub(soap).fetch { nil }
+              mock(soap).fetch(anything).times(timerange.length)
+
+              soap.each(since_at) { }
+            end
+
+            def test_each_invoke_fetch_with_specified_time
+              since_at = "2015-07-06"
+              timerange = soap.send(:generate_time_range, since_at)
+
+              request = {
+                lead_selector: {
+                  oldest_updated_at: timerange.first[:from].iso8601,
+                  latest_updated_at: timerange.first[:to].iso8601,
+                },
+                attributes!: {lead_selector: {"xsi:type"=>"ns1:LastUpdateAtSelector"}},
+                batch_size: 250
+              }
+
+              stub(soap).fetch { nil }
+              mock(soap).fetch(request)
+
+              soap.each(since_at) { }
+            end
+
+            def test_each_fetch_next_page
+              since_at = "2015-07-06 00:00:00"
+              until_at = "2015-07-06 00:00:01"
+
+              any_instance_of(Savon::Client) do |klass|
+                mock(klass).call(:get_multiple_leads, anything) do
+                  next_stream_leads_response
+                end
+              end
+
+              proc = proc{ "" }
+              leads_count = next_stream_leads_response.xpath('//leadRecord').length
+              mock(proc).call(anything).times(leads_count)
+
+              soap.each(since_at, until_at, &proc)
+            end
+          end
+
+          class TestGenerateTime < self
+            def setup
+              mute_logger
+            end
+
+            data do
+              {
+                "8/1 to 8/2" => ["2015-08-01 00:00:00", "2015-08-02 00:00:00", 24],
+                "from 10 minutes ago to nil(now)" => [Time.now - 600, nil, 1],
+                "over the days" => ["2015-08-01 19:00:00", "2015-08-03 05:00:00", 34],
+                "odd times" => ["2015-08-01 11:11:11", "2015-08-01 22:22:22", 12],
+              }
+            end
+            def test_generate_time_range_by_1hour(data)
+              from, to, count = data
+              range = soap.send(:generate_time_range, from, to)
+              assert_equal count, range.length
+            end
           end
 
           class TestMetadata < self
             def setup
+              super
               @savon = soap.__send__(:savon)
               stub(soap).savon { @savon } # Pin savon instance for each call soap.savon for mocking/stubbing
             end

--- a/test/embulk/input/marketo_api/soap/test_lead.rb
+++ b/test/embulk/input/marketo_api/soap/test_lead.rb
@@ -20,20 +20,20 @@ module Embulk
             end
 
             def test_each_invoke_fetch
-              since_at = "2015-07-06"
+              from_datetime = "2015-07-06"
               until_at = "2015-07-07"
-              timerange = soap.send(:generate_time_range, since_at, until_at)
+              timerange = soap.send(:generate_time_range, from_datetime, until_at)
 
               stub(soap).fetch { nil }
               mock(soap).fetch(anything).times(timerange.length)
 
-              soap.each(since_at, until_at) { }
+              soap.each(from_datetime, until_at) { }
             end
 
             def test_each_invoke_fetch_with_specified_time
-              since_at = "2015-07-06"
+              from_datetime = "2015-07-06"
               until_at = "2015-07-07"
-              timerange = soap.send(:generate_time_range, since_at, until_at)
+              timerange = soap.send(:generate_time_range, from_datetime, until_at)
 
               request = {
                 lead_selector: {
@@ -47,11 +47,11 @@ module Embulk
               stub(soap).fetch { nil }
               mock(soap).fetch(request)
 
-              soap.each(since_at, until_at) { }
+              soap.each(from_datetime, until_at) { }
             end
 
             def test_each_fetch_next_page
-              since_at = "2015-07-06 00:00:00"
+              from_datetime = "2015-07-06 00:00:00"
               until_at = "2015-07-06 00:00:01"
 
               any_instance_of(Savon::Client) do |klass|
@@ -64,7 +64,7 @@ module Embulk
               leads_count = next_stream_leads_response.xpath('//leadRecord').length
               mock(proc).call(anything).times(leads_count)
 
-              soap.each(since_at, until_at, &proc)
+              soap.each(from_datetime, until_at, &proc)
             end
           end
 

--- a/test/mute_logger.rb
+++ b/test/mute_logger.rb
@@ -1,0 +1,7 @@
+module MuteLogger
+  private
+
+  def mute_logger
+    stub(Embulk).logger { ::Logger.new(IO::NULL) }
+  end
+end


### PR DESCRIPTION
:fallen_leaf: Some breaking changes including as described on README. :fallen_leaf: 

Each request takes ~30 seconds on my tests (before this change ~2 minutes).
But whole process throughput is slightly decreased before this changes.

We'll make this plugin to work in multithreading after this PR merged for more speed.