### PR TITLE
Fix handling for activity_date_time

### DIFF
--- a/lib/embulk/input/marketo/activity_log.rb
+++ b/lib/embulk/input/marketo/activity_log.rb
@@ -39,7 +39,7 @@ module Embulk
               value = activity_log[name]
               next unless value
 
-              case column["type"]
+              case column["type"].to_s
               when "timestamp"
                 Time.parse(value)
               else

--- a/lib/embulk/input/marketo_api/soap/activity_log.rb
+++ b/lib/embulk/input/marketo_api/soap/activity_log.rb
@@ -69,8 +69,7 @@ module Embulk
             activities.each do |activity|
               record = {
                 "id" => activity[:id],
-                # embulk can't treat DateTime
-                "activity_date_time" => Time.parse(activity[:activity_date_time]),
+                "activity_date_time" => activity[:activity_date_time],
                 "activity_type" => activity[:activity_type],
                 "mktg_asset_name" => activity[:mktg_asset_name],
                 "mkt_person_id" => activity[:mkt_person_id],

--- a/test/activity_log_fixtures.rb
+++ b/test/activity_log_fixtures.rb
@@ -31,7 +31,7 @@ module ActivityLogFixtures
       remaining_count: "1",
       new_start_position: {
         latest_created_at: true,
-        oldest_created_at: "2015-07-14T00:13:13+00:00",
+        oldest_created_at: "2015-07-14T00:13:13+0000",
         activity_created_at: true,
         offset: offset,
       },
@@ -39,7 +39,7 @@ module ActivityLogFixtures
         lead_change_record: [
           {
             id: "1",
-            activity_date_time: "2015-07-14T00:00:09+00:00",
+            activity_date_time: "2015-07-14T00:00:09+0000",
             activity_type: "at1",
             mktg_asset_name: "score1",
             activity_attributes: {
@@ -60,7 +60,7 @@ module ActivityLogFixtures
           },
           {
             id: "2",
-            activity_date_time: "2015-07-14T00:00:10+00:00",
+            activity_date_time: "2015-07-14T00:00:10+0000",
             activity_type: "at2",
             mktg_asset_name: "score2",
             activity_attributes: {
@@ -98,7 +98,7 @@ module ActivityLogFixtures
         lead_change_record: [
           {
             id: "3",
-            activity_date_time: "2015-07-14T00:00:11+00:00",
+            activity_date_time: "2015-07-14T00:00:11+0000",
             activity_type: "at3",
             mktg_asset_name: "score3",
             activity_attributes: {
@@ -126,7 +126,7 @@ module ActivityLogFixtures
     records = (1..15).map do |i|
       {
         id: i,
-        activity_date_time: "2015-07-14T00:00:11+00:00",
+        activity_date_time: "2015-07-14T00:00:11+0000",
         activity_type: "at#{i}",
         mktg_asset_name: "score#{i}",
         activity_attributes: {

--- a/test/embulk/input/marketo/test_activity_log.rb
+++ b/test/embulk/input/marketo/test_activity_log.rb
@@ -102,9 +102,9 @@ module Embulk
               end
             end
 
-            mock(@page_builder).add(["1", Time.parse("2015-07-14 09:00:09 +0900"), "at1", "score1", "100", "Attribute1", "402"])
-            mock(@page_builder).add(["2", Time.parse("2015-07-14 09:00:10 +0900"), "at2", "score2", "90", "Attribute2", "403"])
-            mock(@page_builder).add(["3", Time.parse("2015-07-14 09:00:11 +0900"), "at3", "score3", "100", "Attribute3", "404"])
+            mock(@page_builder).add(["1", "2015-07-14T00:00:09+0000", "at1", "score1", "100", "Attribute1", "402"])
+            mock(@page_builder).add(["2", "2015-07-14T00:00:10+0000", "at2", "score2", "90", "Attribute2", "403"])
+            mock(@page_builder).add(["3", "2015-07-14T00:00:11+0000", "at3", "score3", "100", "Attribute3", "404"])
             mock(@page_builder).finish
 
             @plugin.run
@@ -134,7 +134,7 @@ module Embulk
             end
 
             1.upto(ActivityLog::PREVIEW_COUNT) do |count|
-              mock(@page_builder).add([count, Time.parse("2015-07-14 09:00:11 +0900"), "at#{count}", "score#{count}", "100", "Attribute#{count}", "404"])
+              mock(@page_builder).add([count, "2015-07-14T00:00:11+0000", "at#{count}", "score#{count}", "100", "Attribute#{count}", "404"])
             end
             mock(@page_builder).finish
 

--- a/test/embulk/input/marketo/test_activity_log.rb
+++ b/test/embulk/input/marketo/test_activity_log.rb
@@ -102,9 +102,9 @@ module Embulk
               end
             end
 
-            mock(@page_builder).add(["1", "2015-07-14T00:00:09+0000", "at1", "score1", "100", "Attribute1", "402"])
-            mock(@page_builder).add(["2", "2015-07-14T00:00:10+0000", "at2", "score2", "90", "Attribute2", "403"])
-            mock(@page_builder).add(["3", "2015-07-14T00:00:11+0000", "at3", "score3", "100", "Attribute3", "404"])
+            mock(@page_builder).add(["1", Time.parse("2015-07-14T00:00:09+0000"), "at1", "score1", "100", "Attribute1", "402"])
+            mock(@page_builder).add(["2", Time.parse("2015-07-14T00:00:10+0000"), "at2", "score2", "90", "Attribute2", "403"])
+            mock(@page_builder).add(["3", Time.parse("2015-07-14T00:00:11+0000"), "at3", "score3", "100", "Attribute3", "404"])
             mock(@page_builder).finish
 
             @plugin.run
@@ -134,7 +134,7 @@ module Embulk
             end
 
             1.upto(ActivityLog::PREVIEW_COUNT) do |count|
-              mock(@page_builder).add([count, "2015-07-14T00:00:11+0000", "at#{count}", "score#{count}", "100", "Attribute#{count}", "404"])
+              mock(@page_builder).add([count, Time.parse("2015-07-14T00:00:11+0000"), "at#{count}", "score#{count}", "100", "Attribute#{count}", "404"])
             end
             mock(@page_builder).finish
 

--- a/test/embulk/input/marketo_api/soap/test_activity_log.rb
+++ b/test/embulk/input/marketo_api/soap/test_activity_log.rb
@@ -89,7 +89,7 @@ module Embulk
             def schema
               metadata = [
                 {index: 0, name: "id", type: :long},
-                {index: 1, name: "activity_date_time", type: :timestamp, format: "%Y-%m-%d %H:%M:%S %z"},
+                {index: 1, name: "activity_date_time", type: :timestamp, format: "%Y-%m-%dT%H:%M:%S%z"}, # NOTE: `format` is the same as-is response (e.g. "2015-07-14T00:00:11+0000" to "%Y-%m-%dT%H:%M:%S%z")
                 {index: 2, name: "activity_type", type: :string},
                 {index: 3, name: "mktg_asset_name", type: :string},
                 {index: 4, name: "mkt_person_id", type: :long},


### PR DESCRIPTION
`activity_date_time` was Time.parse-ed twice (on `fetch`, and before `page_builder.add`) that caused error at 2nd Time.parse.
This PR fixes that `fetch` don't care for each column type. It *passed* as Time object, but *now passing* String object.