### PR TITLE
Catch config error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ gemfile:
   - gemfiles/embulk-0.6.21
   - gemfiles/embulk-0.6.22
   - gemfiles/embulk-0.6.23
+  - gemfiles/embulk-0.6.24
+  - gemfiles/embulk-0.6.25
+  - gemfiles/embulk-0.6.26
   - gemfiles/embulk-latest
 matrix:
   allow_failures:

--- a/gemfiles/embulk-0.6.26
+++ b/gemfiles/embulk-0.6.26
@@ -1,0 +1,4 @@
+source 'https://rubygems.org/'
+gemspec :path => '../'
+
+gem "embulk", "0.6.26"

--- a/lib/embulk/input/marketo/activity_log.rb
+++ b/lib/embulk/input/marketo/activity_log.rb
@@ -41,7 +41,11 @@ module Embulk
 
               case column["type"].to_s
               when "timestamp"
-                Time.parse(value)
+                begin
+                  Time.parse(value)
+                rescue => e
+                  raise ConfigError, "Can't parse as Time '#{value}' (column is #{column["name"]})"
+                end
               else
                 value
               end

--- a/lib/embulk/input/marketo/lead.rb
+++ b/lib/embulk/input/marketo/lead.rb
@@ -64,7 +64,11 @@ module Embulk
 
                 case column["type"]
                 when "timestamp"
-                  Time.parse(value)
+                  begin
+                    Time.parse(value)
+                  rescue => e
+                    raise ConfigError, "Can't parse as Time '#{value}' (column is #{column["name"]})"
+                  end
                 else
                   value
                 end

--- a/lib/embulk/input/marketo/timeslice.rb
+++ b/lib/embulk/input/marketo/timeslice.rb
@@ -30,6 +30,15 @@ module Embulk
             from_datetime = config.param(:from_datetime, :string)
             to_datetime = config.param(:to_datetime, :string, default: Time.now.to_s)
 
+            # check from/to format to parse
+            begin
+              Time.parse(from_datetime)
+              Time.parse(to_datetime)
+            rescue => e
+              # possibly Time.parse fail
+              raise ConfigError, e.message
+            end
+
             if Time.parse(from_datetime) > Time.parse(to_datetime)
               raise ConfigError, "config: from_datetime '#{from_datetime}' is later than '#{to_datetime}'."
             end

--- a/test/embulk/input/marketo/test_activity_log.rb
+++ b/test/embulk/input/marketo/test_activity_log.rb
@@ -141,6 +141,26 @@ module Embulk
             @plugin.run
           end
 
+          def test_wrong_type
+            any_instance_of(Savon::Client) do |klass|
+              stub(klass).call(:get_lead_changes, message: request) do
+                next_stream_activity_logs_response
+              end
+            end
+            stub(@page_builder).add {}
+            stub(@page_builder).finish {}
+
+            task = task()
+            task[:columns] = [
+              {"name" => "Old Value", "type" => :timestamp}
+            ]
+            @plugin = ActivityLog.new(task, nil, nil, @page_builder)
+
+            assert_raise(Embulk::ConfigError) do
+              @plugin.run
+            end
+          end
+
           private
 
           def request

--- a/test/embulk/input/marketo/test_lead.rb
+++ b/test/embulk/input/marketo/test_lead.rb
@@ -54,8 +54,8 @@ module Embulk
           control = proc {} # dummy
 
           settings = {
-            endpoint_url: "https://marketo.example.com",
-            wsdl_url: "https://marketo.example.com/?wsdl",
+            endpoint: "https://marketo.example.com",
+            wsdl: "https://marketo.example.com/?wsdl",
             user_id: "user_id",
             encryption_key: "TOPSECRET",
             from_datetime: "invalid time from",
@@ -75,8 +75,8 @@ module Embulk
           control = proc {} # dummy
 
           settings = {
-            endpoint_url: "https://marketo.example.com",
-            wsdl_url: "https://marketo.example.com/?wsdl",
+            endpoint: "https://marketo.example.com",
+            wsdl: "https://marketo.example.com/?wsdl",
             user_id: "user_id",
             encryption_key: "TOPSECRET",
             from_datetime: "invalid time from",

--- a/test/embulk/input/marketo/test_lead.rb
+++ b/test/embulk/input/marketo/test_lead.rb
@@ -50,6 +50,49 @@ module Embulk
           end
         end
 
+        def test_invalid_datetime_given
+          control = proc {} # dummy
+
+          settings = {
+            endpoint_url: "https://marketo.example.com",
+            wsdl_url: "https://marketo.example.com/?wsdl",
+            user_id: "user_id",
+            encryption_key: "TOPSECRET",
+            from_datetime: "invalid time from",
+            to_datetime: "invalid time to",
+            columns: [
+              {"name" => "Name", "type" => "string"},
+            ]
+          }
+          config = DataSource[settings.to_a]
+
+          assert_raise(ConfigError) do
+            Lead.transaction(config, &control)
+          end
+        end
+
+        def test_wrong_type
+          control = proc {} # dummy
+
+          settings = {
+            endpoint_url: "https://marketo.example.com",
+            wsdl_url: "https://marketo.example.com/?wsdl",
+            user_id: "user_id",
+            encryption_key: "TOPSECRET",
+            from_datetime: "invalid time from",
+            to_datetime: "invalid time to",
+            columns: [
+              {"name" => "Name", "type" => "timestamp"},
+            ]
+          }
+
+          config = DataSource[settings.to_a]
+
+          assert_raise(ConfigError) do
+            Lead.transaction(config, &control)
+          end
+        end
+
         class RunTest < self
           def setup
             setup_soap


### PR DESCRIPTION
This plugin should raise `ConfigError` when failing Time.parse.