### PR TITLE
Fix the bug when from and to is same

### DIFF
--- a/lib/embulk/input/marketo/lead.rb
+++ b/lib/embulk/input/marketo/lead.rb
@@ -42,7 +42,6 @@ module Embulk
         end
 
         def init
-          @last_updated_at = task[:last_updated_at]
           @columns = task[:columns]
           @ranges = task[:ranges][index]
           @soap = MarketoApi.soap_client(task, target)

--- a/lib/embulk/input/marketo/timeslice.rb
+++ b/lib/embulk/input/marketo/timeslice.rb
@@ -107,6 +107,8 @@ module Embulk
           def resume(task, columns, count, &control)
             commit_reports = yield(task, columns, count)
 
+            # When no task ran, commit_reports is empty
+            return {} if commit_reports.empty?
             # all task returns same report as {from_datetime: to_datetime}
             return commit_reports.first
           end

--- a/test/embulk/input/marketo/test_lead.rb
+++ b/test/embulk/input/marketo/test_lead.rb
@@ -95,14 +95,15 @@ module Embulk
 
         def test_same_datetimes_given
           control = proc { [] } # dummy (#resume method returns [])
+          datetime = Time.now.to_s
 
           settings = {
             endpoint: "https://marketo.example.com",
             wsdl: "https://marketo.example.com/?wsdl",
             user_id: "user_id",
             encryption_key: "TOPSECRET",
-            from_datetime: Time.now.to_s,
-            to_datetime: Time.now.to_s,
+            from_datetime: datetime,
+            to_datetime: datetime,
             columns: [
               {"name" => "Name", "type" => "string"},
             ]

--- a/test/embulk/input/marketo/test_lead.rb
+++ b/test/embulk/input/marketo/test_lead.rb
@@ -93,6 +93,25 @@ module Embulk
           end
         end
 
+        def test_same_datetimes_given
+          control = proc { [] } # dummy (#resume method returns [])
+
+          settings = {
+            endpoint: "https://marketo.example.com",
+            wsdl: "https://marketo.example.com/?wsdl",
+            user_id: "user_id",
+            encryption_key: "TOPSECRET",
+            from_datetime: Time.now.to_s,
+            to_datetime: Time.now.to_s,
+            columns: [
+              {"name" => "Name", "type" => "string"},
+            ]
+          }
+          config = DataSource[settings.to_a]
+
+          assert_equal({}, Lead.transaction(config, &control))
+        end
+
         class RunTest < self
           def setup
             setup_soap


### PR DESCRIPTION
When `from_datetime` / `to_datetime` are same, `#run` isn't called, so `.resume` returns `[]` (expected non-zero size Array object) as `commit_reports`.
When `commit_reports` is empty, this plugin crashes because `.resume` `commit_reports` returns `nil` but Embulk transaction phase can't treat it.