### PR TITLE
Unsupport scheduled execution for lead

### DIFF
--- a/lib/embulk/input/marketo/lead.rb
+++ b/lib/embulk/input/marketo/lead.rb
@@ -26,10 +26,7 @@ module Embulk
         def self.resume(task, columns, count, &control)
           task_reports = yield(task, columns, count)
 
-          # When no task ran, task_reports is empty
-          return {} if task_reports.empty?
-          # all task returns same report as {from_datetime: to_datetime}
-          return task_reports.first
+          return {}
         end
 
         def self.transaction(config, &control)
@@ -107,9 +104,7 @@ module Embulk
 
           page_builder.finish
 
-          task_report = {
-            from_datetime: task[:to_datetime]
-          }
+          task_report = {}
           return task_report
         end
       end

--- a/test/embulk/input/marketo/test_lead.rb
+++ b/test/embulk/input/marketo/test_lead.rb
@@ -142,13 +142,13 @@ module Embulk
             @plugin.run
           end
 
-          def test_run_commit_report
+          def test_run_task_report
             # do not requests
             stub(@page_builder).finish
             stub(@plugin.soap).each { }
 
-            commit_report = @plugin.run
-            assert_equal({}, commit_report)
+            task_report = @plugin.run
+            assert_equal({}, task_report)
           end
 
           def test_preview_through

--- a/test/embulk/input/marketo/test_lead.rb
+++ b/test/embulk/input/marketo/test_lead.rb
@@ -148,7 +148,7 @@ module Embulk
             stub(@plugin.soap).each { }
 
             commit_report = @plugin.run
-            assert_equal to_datetime, commit_report[:from_datetime]
+            assert_equal({}, commit_report)
           end
 
           def test_preview_through


### PR DESCRIPTION
We use last_updated_at to get multiple leads, so scheduled execution may fetch duplicated leads in from/to generated by commit report.