### PR TITLE
Refactor lead and activity

### DIFF
--- a/lib/embulk/input/marketo/activity_log.rb
+++ b/lib/embulk/input/marketo/activity_log.rb
@@ -69,13 +69,7 @@ module Embulk
         def run
           counter = 0
           latest_updated_at = @soap.each(task[:from_datetime], @options) do |activity_log|
-            values = @columns.map do |column|
-              name = column["name"].to_s
-              value = activity_log[name]
-              cast_value(column, value)
-            end
-
-            page_builder.add(values)
+            page_builder.add(format_record(activity_log))
             break if preview? && (counter += 1) >= PREVIEW_COUNT
           end
 
@@ -87,6 +81,14 @@ module Embulk
           end
 
           return task_report
+        end
+
+        def format_record(activity_log)
+          @columns.map do |column|
+            name = column["name"].to_s
+            value = activity_log[name]
+            cast_value(column, value)
+          end
         end
       end
     end

--- a/lib/embulk/input/marketo/activity_log.rb
+++ b/lib/embulk/input/marketo/activity_log.rb
@@ -58,18 +58,17 @@ module Embulk
         def init
           @columns = task[:columns]
           @soap = MarketoApi.soap_client(task, target)
-        end
-
-        def run
-          options = {
+          @options = {
             retry_initial_wait_sec: task[:retry_initial_wait_sec],
             retry_limit: task[:retry_limit],
             to: task[:to_datetime],
             batch_size: (preview? ? PREVIEW_COUNT : BATCH_SIZE_DEFAULT),
           }
+        end
 
+        def run
           counter = 0
-          latest_updated_at = @soap.each(task[:from_datetime], options) do |activity_log|
+          latest_updated_at = @soap.each(task[:from_datetime], @options) do |activity_log|
             values = @columns.map do |column|
               name = column["name"].to_s
               value = activity_log[name]

--- a/lib/embulk/input/marketo/lead.rb
+++ b/lib/embulk/input/marketo/lead.rb
@@ -106,17 +106,7 @@ module Embulk
           catch(:finish) do
             @ranges.each do |range|
               soap.each(range, @options) do |lead|
-                values = @columns.map do |column|
-                  name = column["name"].to_s
-                  value = (lead[name] || {})[:value]
-                  cast_value(column, value)
-                end
-
-                if @append_processed_time_column
-                  values << Time.parse(range["from"])
-                end
-
-                page_builder.add(values)
+                page_builder.add(format_record(lead, range))
                 throw(:finish) if preview? && (counter += 1) >= PREVIEW_COUNT
               end
             end
@@ -126,6 +116,19 @@ module Embulk
 
           task_report = {}
           return task_report
+        end
+
+        def format_record(lead, range)
+          values = @columns.map do |column|
+            name = column["name"].to_s
+            value = (lead[name] || {})[:value]
+            cast_value(column, value)
+          end
+
+          if @append_processed_time_column
+            values << Time.parse(range["from"])
+          end
+          values
         end
       end
     end

--- a/lib/embulk/input/marketo/lead.rb
+++ b/lib/embulk/input/marketo/lead.rb
@@ -94,19 +94,18 @@ module Embulk
           @ranges = task[:ranges][index]
           @soap = MarketoApi.soap_client(task, target)
           @append_processed_time_column = task[:append_processed_time_column]
-        end
-
-        def run
-          options = {
+          @options = {
             retry_initial_wait_sec: task[:retry_initial_wait_sec],
             retry_limit: task[:retry_limit],
           }
-          options[:batch_size] = PREVIEW_COUNT if preview?
+          @options[:batch_size] = PREVIEW_COUNT if preview?
+        end
 
+        def run
           counter = 0
           catch(:finish) do
             @ranges.each do |range|
-              soap.each(range, options) do |lead|
+              soap.each(range, @options) do |lead|
                 values = @columns.map do |column|
                   name = column["name"].to_s
                   value = (lead[name] || {})[:value]

--- a/lib/embulk/input/marketo_api/soap/activity_log.rb
+++ b/lib/embulk/input/marketo_api/soap/activity_log.rb
@@ -68,22 +68,7 @@ module Embulk
             end
 
             activities.each do |activity|
-              record = {
-                "id" => activity.at("./id").text,
-                "activity_date_time" => activity.at('./activityDateTime').text,
-                "activity_type" => activity.at('./activityType').text,
-                "mktg_asset_name" => activity.at('./mktgAssetName').text,
-                "mkt_person_id" => activity.at('./mktPersonId').text,
-              }
-
-              activity.xpath('./activityAttributes/attribute').each do |attr|
-                name = attr.xpath('attrName').text
-                value = attr.xpath('attrValue').text
-
-                record[name] = value
-              end
-
-              block.call(record)
+              process_record(activity, &block)
             end
 
             {
@@ -91,6 +76,25 @@ module Embulk
               offset: response.xpath('//newStartPosition/offset').text,
               from_datetime: activities.map{|a| Time.parse(a.at('./activityDateTime').text) }.max,
             }
+          end
+
+          def process_record(activity, &block)
+            record = {
+              "id" => activity.at("./id").text,
+              "activity_date_time" => activity.at('./activityDateTime').text,
+              "activity_type" => activity.at('./activityType').text,
+              "mktg_asset_name" => activity.at('./mktgAssetName').text,
+              "mkt_person_id" => activity.at('./mktPersonId').text,
+            }
+
+            activity.xpath('./activityAttributes/attribute').each do |attr|
+              name = attr.xpath('attrName').text
+              value = attr.xpath('attrValue').text
+
+              record[name] = value
+            end
+
+            block.call(record)
           end
         end
       end

--- a/test/activity_log_fixtures.rb
+++ b/test/activity_log_fixtures.rb
@@ -5,171 +5,156 @@ module ActivityLogFixtures
 
   private
 
-  def activity_logs_response
-    activity_logs(response)
+  def activity_log_xml(body)
+    <<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns1="http://www.marketo.com/mktows/">
+  <SOAP-ENV:Body>
+    <ns1:successGetLeadChanges>
+      <result>
+        #{body}
+      </result>
+    </ns1:successGetLeadChanges>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>
+XML
   end
 
-  def next_stream_activity_logs_response
-    activity_logs(next_stream_response)
+  def xml_ac_response
+    activity_log_xml <<XML
+<returnCount>2</returnCount>
+<remainingCount>1</remainingCount>
+<newStartPosition>
+  <latestCreatedAt>2015-07-14T09:13:10+09:00</latestCreatedAt>
+  <oldestCreatedAt>2015-07-14T09:13:13+09:00</oldestCreatedAt>
+  <activityCreatedAt xsi:nil="true"/>
+  <offset>offset</offset>
+</newStartPosition>
+<leadChangeRecordList>
+  <leadChangeRecord>
+    <id>1</id>
+    <activityDateTime>2015-07-14T09:00:09+09:00</activityDateTime>
+    <activityType>at1</activityType>
+    <mktgAssetName>score1</mktgAssetName>
+    <activityAttributes>
+      <attribute>
+        <attrName>Attribute Name</attrName>
+        <attrType xsi:nil="true"/>
+        <attrValue>Attribute1</attrValue>
+      </attribute>
+      <attribute>
+        <attrName>Old Value</attrName>
+        <attrType xsi:nil="true"/>
+        <attrValue>402</attrValue>
+      </attribute>
+    </activityAttributes>
+    <mktPersonId>100</mktPersonId>
+  </leadChangeRecord>
+  <leadChangeRecord>
+    <id>2</id>
+    <activityDateTime>2015-07-14T09:00:10+09:00</activityDateTime>
+    <activityType>at2</activityType>
+    <mktgAssetName>score2</mktgAssetName>
+    <activityAttributes>
+      <attribute>
+        <attrName>Attribute Name</attrName>
+        <attrType xsi:nil="true"/>
+        <attrValue>Attribute2</attrValue>
+      </attribute>
+      <attribute>
+        <attrName>Old Value</attrName>
+        <attrType xsi:nil="true"/>
+        <attrValue>403</attrValue>
+      </attribute>
+    </activityAttributes>
+    <mktPersonId>90</mktPersonId>
+  </leadChangeRecord>
+</leadChangeRecordList>
+XML
   end
 
-  def preview_activity_logs_response
-    activity_logs(preview_response)
+  def xml_ac_next_response
+    activity_log_xml <<XML
+<returnCount>1</returnCount>
+<remainingCount>0</remainingCount>
+<newStartPosition>
+</newStartPosition>
+<leadChangeRecordList>
+  <leadChangeRecord>
+    <id>3</id>
+    <activityDateTime>2015-07-14T09:00:11+09:00</activityDateTime>
+    <activityType>at3</activityType>
+    <mktgAssetName>score3</mktgAssetName>
+    <activityAttributes>
+      <attribute>
+        <attrName>Attribute Name</attrName>
+        <attrType xsi:nil="true"/>
+        <attrValue>Attribute3</attrValue>
+      </attribute>
+      <attribute>
+        <attrName>Old Value</attrName>
+        <attrType xsi:nil="true"/>
+        <attrValue>404</attrValue>
+      </attribute>
+    </activityAttributes>
+    <mktPersonId>100</mktPersonId>
+  </leadChangeRecord>
+</leadChangeRecordList>
+XML
   end
 
-  def none_activity_log_response
-    activity_logs(none_response)
+  def xml_ac_none_response
+    activity_log_xml <<XML
+<returnCount>0</returnCount>
+<remainingCount>0</remainingCount>
+<newStartPosition>
+</newStartPosition>
+<leadChangeRecordList>
+</leadChangeRecordList>
+XML
   end
 
-  def activity_logs(body)
-    Struct.new(:body).new({
-      success_get_lead_changes: {
-        result: body
-      }
-    })
+  def xml_ac_preview_response
+    activity_log_xml <<XML
+<returnCount>15</returnCount>
+<remainingCount>0</remainingCount>
+<newStartPosition>
+</newStartPosition>
+<leadChangeRecordList>
+#{xml_ac_attr(15)}
+</leadChangeRecordList>
+XML
   end
 
-  def response
-    {
-      return_count: "2",
-      remaining_count: "1",
-      new_start_position: {
-        latest_created_at: true,
-        oldest_created_at: "2015-07-14T00:13:13+0000",
-        activity_created_at: true,
-        offset: offset,
-      },
-      lead_change_record_list: {
-        lead_change_record: [
-          {
-            id: "1",
-            activity_date_time: "2015-07-14T00:00:09+0000",
-            activity_type: "at1",
-            mktg_asset_name: "score1",
-            activity_attributes: {
-              attribute: [
-                {
-                  attr_name: "Attribute Name",
-                  attr_type: nil,
-                  attr_value: "Attribute1",
-                },
-                {
-                  attr_name: "Old Value",
-                  attr_type: nil,
-                  attr_value: "402",
-                },
-              ],
-            },
-            mkt_person_id: "100",
-          },
-          {
-            id: "2",
-            activity_date_time: "2015-07-14T00:00:10+0000",
-            activity_type: "at2",
-            mktg_asset_name: "score2",
-            activity_attributes: {
-              attribute: [
-                {
-                  attr_name: "Attribute Name",
-                  attr_type: nil,
-                  attr_value: "Attribute2",
-                },
-                {
-                  attr_name: "Old Value",
-                  attr_type: nil,
-                  attr_value: "403",
-                },
-              ],
-            },
-            mkt_person_id: "90",
-          },
-        ]
-      }
-    }
+  def xml_ac_attr(times = 15)
+    response = ""
+    (1..times).each do |n|
+    response << <<-XML
+  <leadChangeRecord>
+    <id>#{n}</id>
+    <activityDateTime>2015-07-14T00:00:11+00:00</activityDateTime>
+    <activityType>at#{n}</activityType>
+    <mktgAssetName>score#{n}</mktgAssetName>
+    <activityAttributes>
+      <attribute>
+        <attrName>Attribute Name</attrName>
+        <attrType xsi:nil="true"/>
+        <attrValue>Attribute#{n}</attrValue>
+      </attribute>
+      <attribute>
+        <attrName>Old Value</attrName>
+        <attrType xsi:nil="true"/>
+        <attrValue>404</attrValue>
+      </attribute>
+    </activityAttributes>
+    <mktPersonId>100</mktPersonId>
+  </leadChangeRecord>
+    XML
+    end
+    response
   end
 
   def offset
     "offset"
-  end
-
-  def next_stream_response
-    {
-      return_count: 1,
-      remaining_count: 0,
-      new_start_position: {
-      },
-      lead_change_record_list: {
-        lead_change_record: [
-          {
-            id: "3",
-            activity_date_time: "2015-07-14T00:00:11+0000",
-            activity_type: "at3",
-            mktg_asset_name: "score3",
-            activity_attributes: {
-              attribute: [
-                {
-                  attr_name: "Attribute Name",
-                  attr_type: nil,
-                  attr_value: "Attribute3",
-                },
-                {
-                  attr_name: "Old Value",
-                  attr_type: nil,
-                  attr_value: "404",
-                },
-              ],
-            },
-            mkt_person_id: "100",
-          },
-        ]
-      }
-    }
-  end
-
-  def preview_response
-    records = (1..15).map do |i|
-      {
-        id: i,
-        activity_date_time: "2015-07-14T00:00:11+0000",
-        activity_type: "at#{i}",
-        mktg_asset_name: "score#{i}",
-        activity_attributes: {
-          attribute: [
-            {
-              attr_name: "Attribute Name",
-              attr_type: nil,
-              attr_value: "Attribute#{i}",
-            },
-            {
-              attr_name: "Old Value",
-              attr_type: nil,
-              attr_value: "404",
-            },
-          ],
-        },
-        mkt_person_id: "100",
-      }
-    end
-
-    {
-      return_count: 15,
-      remaining_count: 0,
-      new_start_position: {},
-      lead_change_record_list: {
-        lead_change_record: records
-      }
-    }
-  end
-
-  def none_response
-    {
-      result: {
-        return_count: 0,
-        remaining_count: 0,
-        new_start_position: {
-        },
-        lead_change_record_list: nil
-      }
-    }
   end
 end

--- a/test/activity_log_fixtures.rb
+++ b/test/activity_log_fixtures.rb
@@ -1,4 +1,8 @@
+require "savon_helper"
+
 module ActivityLogFixtures
+  include SavonHelper
+
   private
 
   def activity_logs_response

--- a/test/embulk/input/marketo/test_activity_log.rb
+++ b/test/embulk/input/marketo/test_activity_log.rb
@@ -207,6 +207,7 @@ module Embulk
             mock(@page_builder).add(["3", Time.parse("2015-07-14T00:00:11+0000"), "at3", "score3", "100", "Attribute3", "404"])
             mock(@page_builder).finish
 
+            @plugin.init
             @plugin.run
           end
 
@@ -221,6 +222,7 @@ module Embulk
 
             mock(@page_builder).finish
 
+            @plugin.init
             @plugin.run
           end
 
@@ -238,6 +240,7 @@ module Embulk
             end
             mock(@page_builder).finish
 
+            @plugin.init
             @plugin.run
           end
 
@@ -257,6 +260,7 @@ module Embulk
             @plugin = ActivityLog.new(task, nil, nil, @page_builder)
 
             assert_raise(Embulk::ConfigError) do
+              @plugin.init
               @plugin.run
             end
           end

--- a/test/embulk/input/marketo/test_activity_log.rb
+++ b/test/embulk/input/marketo/test_activity_log.rb
@@ -194,11 +194,11 @@ module Embulk
 
             any_instance_of(Savon::Client) do |klass|
               mock(klass).call(:get_lead_changes, message: request) do
-                activity_logs_response
+                savon_response(xml_ac_response)
               end
 
               mock(klass).call(:get_lead_changes, message: offset_request) do
-                next_stream_activity_logs_response
+                savon_response(xml_ac_next_response)
               end
             end
 
@@ -215,7 +215,7 @@ module Embulk
 
             any_instance_of(Savon::Client) do |klass|
               mock(klass).call(:get_lead_changes, message: request) do
-                none_activity_log_response
+                savon_response xml_ac_none_response
               end
             end
 
@@ -229,12 +229,12 @@ module Embulk
 
             any_instance_of(Savon::Client) do |klass|
               mock(klass).call(:get_lead_changes, message: preview_request) do
-                preview_activity_logs_response
+                savon_response xml_ac_preview_response
               end
             end
 
             1.upto(ActivityLog::PREVIEW_COUNT) do |count|
-              mock(@page_builder).add([count, Time.parse("2015-07-14T00:00:11+0000"), "at#{count}", "score#{count}", "100", "Attribute#{count}", "404"])
+              mock(@page_builder).add([count.to_s, Time.parse("2015-07-14T00:00:11+0000"), "at#{count}", "score#{count}", "100", "Attribute#{count}", "404"])
             end
             mock(@page_builder).finish
 
@@ -244,7 +244,7 @@ module Embulk
           def test_wrong_type
             any_instance_of(Savon::Client) do |klass|
               stub(klass).call(:get_lead_changes, message: request) do
-                next_stream_activity_logs_response
+                savon_response xml_ac_next_response
               end
             end
             stub(@page_builder).add {}

--- a/test/embulk/input/marketo/test_lead.rb
+++ b/test/embulk/input/marketo/test_lead.rb
@@ -126,11 +126,11 @@ module Embulk
 
             any_instance_of(Savon::Client) do |klass|
               mock(klass).call(:get_multiple_leads, message: request) do
-                savon_response(raw_response)
+                savon_response(xml_lead_response)
               end
 
               mock(klass).call(:get_multiple_leads, message: request.merge(stream_position: stream_position)) do
-                savon_response(raw_next_stream_response)
+                savon_response(xml_lead_next)
               end
             end
 
@@ -152,11 +152,11 @@ module Embulk
 
             any_instance_of(Savon::Client) do |klass|
               mock(klass).call(:get_multiple_leads, message: request) do
-                savon_response(raw_response)
+                savon_response(xml_lead_response)
               end
 
               mock(klass).call(:get_multiple_leads, message: request.merge(stream_position: stream_position)) do
-                savon_response(raw_next_stream_response)
+                savon_response(xml_lead_next)
               end
             end
 
@@ -184,7 +184,7 @@ module Embulk
 
             any_instance_of(Savon::Client) do |klass|
               mock(klass).call(:get_multiple_leads, message: request.merge(batch_size: Lead::PREVIEW_COUNT)) do
-                savon_response(raw_preview_response)
+                savon_response(xml_lead_preview)
               end
             end
 
@@ -204,7 +204,7 @@ module Embulk
 
             any_instance_of(Savon::Client) do |klass|
               mock(klass).call(:get_multiple_leads, anything) do
-                savon_response(raw_preview_response)
+                savon_response(xml_lead_preview)
               end
             end
 

--- a/test/embulk/input/marketo/test_lead.rb
+++ b/test/embulk/input/marketo/test_lead.rb
@@ -140,6 +140,7 @@ module Embulk
             mock(@page_builder).add(["ten-thousand-leaf", from])
             mock(@page_builder).finish
 
+            @plugin.init
             @plugin.run
           end
 
@@ -165,6 +166,7 @@ module Embulk
             mock(@page_builder).add(["ten-thousand-leaf"])
             mock(@page_builder).finish
 
+            @plugin.init
             @plugin.run
           end
 
@@ -194,6 +196,7 @@ module Embulk
             end
             mock(@page_builder).finish
 
+            @plugin.init
             @plugin.run
           end
 
@@ -211,6 +214,7 @@ module Embulk
             mock(@page_builder).add(anything).times(Lead::PREVIEW_COUNT)
             mock(@page_builder).finish
 
+            @plugin.init
             @plugin.run
           end
 
@@ -227,6 +231,7 @@ module Embulk
             stub(Embulk.logger).info {}
 
             assert_raise do
+              @plugin.init
               @plugin.run
             end
           end
@@ -267,6 +272,7 @@ module Embulk
               stub(@soap).endpoint { "http://foo.test/" }
 
               assert_raise(Embulk::ConfigError) do
+                @plugin.init
                 @plugin.run
               end
             end

--- a/test/embulk/input/marketo_api/soap/test_lead.rb
+++ b/test/embulk/input/marketo_api/soap/test_lead.rb
@@ -47,12 +47,12 @@ module Embulk
 
               any_instance_of(Savon::Client) do |klass|
                 mock(klass).call(:get_multiple_leads, anything) do
-                  next_stream_leads_response
+                  savon_response(raw_next_stream_response)
                 end
               end
 
               proc = proc{ "" }
-              leads_count = next_stream_leads_response.xpath('//leadRecord').length
+              leads_count = savon_response(raw_next_stream_response).xpath('//leadRecord').length
               mock(proc).call(anything).times(leads_count)
 
               soap.each(timerange, {}, &proc)

--- a/test/embulk/input/marketo_api/soap/test_lead.rb
+++ b/test/embulk/input/marketo_api/soap/test_lead.rb
@@ -47,12 +47,12 @@ module Embulk
 
               any_instance_of(Savon::Client) do |klass|
                 mock(klass).call(:get_multiple_leads, anything) do
-                  savon_response(raw_next_stream_response)
+                  savon_response(xml_lead_next)
                 end
               end
 
               proc = proc{ "" }
-              leads_count = savon_response(raw_next_stream_response).xpath('//leadRecord').length
+              leads_count = savon_response(xml_lead_next).xpath('//leadRecord').length
               mock(proc).call(anything).times(leads_count)
 
               soap.each(timerange, {}, &proc)

--- a/test/lead_fixtures.rb
+++ b/test/lead_fixtures.rb
@@ -1,4 +1,8 @@
+require "savon_helper"
+
 module LeadFixtures
+  include SavonHelper
+
   private
 
   def leads_response

--- a/test/lead_fixtures.rb
+++ b/test/lead_fixtures.rb
@@ -5,7 +5,7 @@ module LeadFixtures
 
   private
 
-  def leads(body)
+  def leads_xml(body)
     <<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns1="http://www.marketo.com/mktows/">
@@ -20,8 +20,8 @@ module LeadFixtures
 XML
   end
 
-  def raw_response
-    leads(<<XML)
+  def xml_lead_response
+    leads_xml(<<XML)
 <remainingCount>1</remainingCount>
 <newStreamPosition>#{stream_position}</newStreamPosition>
 <leadRecordList>
@@ -59,8 +59,8 @@ XML
     "next_steam_position"
   end
 
-  def raw_next_stream_response
-    leads(<<XML)
+  def xml_lead_next
+    leads_xml(<<XML)
 <returnCount>2</returnCount>
 <remainingCount>0</remainingCount>
 <newStreamPosition />
@@ -82,7 +82,7 @@ XML
 XML
   end
 
-  def raw_preview_response
+  def xml_lead_preview
     body = ""
     15.times do |i|
       body << <<XML
@@ -106,6 +106,6 @@ XML
 </leadRecordList>
 XML
     end
-    leads(body)
+    leads_xml(body)
   end
 end

--- a/test/lead_fixtures.rb
+++ b/test/lead_fixtures.rb
@@ -5,18 +5,6 @@ module LeadFixtures
 
   private
 
-  def leads_response
-    Nokogiri::XML(raw_response)
-  end
-
-  def next_stream_leads_response
-    Nokogiri::XML(raw_next_stream_response)
-  end
-
-  def preview_leads_response
-    Nokogiri::XML(raw_preview_response)
-  end
-
   def leads(body)
     <<XML
 <?xml version="1.0" encoding="UTF-8"?>

--- a/test/savon_helper.rb
+++ b/test/savon_helper.rb
@@ -1,0 +1,21 @@
+module SavonHelper
+  private
+
+  def savon_response(body)
+    globals = {
+      namespace_identifier: :ns1,
+      env_namespace: 'SOAP-ENV',
+    }
+    httpi = HTTPI::Response.new(200, {}, body)
+    Savon::Response.new(httpi, globals.merge(default_nori_options), {advanced_typecasting: false})
+  end
+
+  def default_nori_options
+    # https://github.com/savonrb/savon/blob/v2.11.1/lib/savon/options.rb#L75-L94
+    {
+      :strip_namespaces          => true,
+      :convert_tags_to  => lambda { |tag| tag.snakecase.to_sym},
+      :convert_attributes_to     => lambda { |k,v| [k,v] },
+    }
+  end
+end

--- a/test/savon_helper.rb
+++ b/test/savon_helper.rb
@@ -5,17 +5,13 @@ module SavonHelper
     globals = {
       namespace_identifier: :ns1,
       env_namespace: 'SOAP-ENV',
+
+      # https://github.com/savonrb/savon/blob/v2.11.1/lib/savon/options.rb#L75-L94
+      strip_namespaces:         true,
+      convert_response_tags_to: lambda { |tag| tag.snakecase.to_sym},
+      convert_attributes_to:    lambda { |k,v| [k,v] },
     }
     httpi = HTTPI::Response.new(200, {}, body)
-    Savon::Response.new(httpi, globals.merge(default_nori_options), {advanced_typecasting: false})
-  end
-
-  def default_nori_options
-    # https://github.com/savonrb/savon/blob/v2.11.1/lib/savon/options.rb#L75-L94
-    {
-      :strip_namespaces          => true,
-      :convert_tags_to  => lambda { |tag| tag.snakecase.to_sym},
-      :convert_attributes_to     => lambda { |k,v| [k,v] },
-    }
+    Savon::Response.new(httpi, globals, {advanced_typecasting: false})
   end
 end


### PR DESCRIPTION
- Use XPath on both lead and activity_log. Using hash is ambiguous than XPath e.g. `<a><b>hi</b></a>` and `<a><b>hi</b><b>hello</b></a>`, first one will be cast as  `{a: {b: "hi"} }`, second one will be  `{a: {b: ["hi", "hello"]}}`
- Mocking Savon::Response on test
- Some large method separation