### PR TITLE
Recognize empty string as nil value

### DIFF
--- a/lib/embulk/input/marketo/base.rb
+++ b/lib/embulk/input/marketo/base.rb
@@ -108,7 +108,7 @@ module Embulk
         end
 
         def cast_value(column, value)
-          return unless value
+          return if value.to_s.empty? # nil or empty string
 
           case column["type"].to_s
           when "timestamp"


### PR DESCRIPTION
Sometimes Marketo returns empty timestamp string.
We treat it as `nil` instead of raising error.