### PR TITLE
Make debug easier

### DIFF
--- a/embulk-input-marketo.gemspec
+++ b/embulk-input-marketo.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'savon', ['~> 2.11.1']
   spec.add_dependency 'httpclient'
-  spec.add_dependency 'perfect_retry', ["~> 0.3"]
+  spec.add_dependency 'perfect_retry', ["~> 0.5"]
   spec.add_development_dependency 'embulk', [">= 0.6.13", "< 1.0"]
   spec.add_development_dependency 'bundler', ['~> 1.0']
   spec.add_development_dependency 'rake', ['>= 10.0']

--- a/lib/embulk/input/marketo_api/soap/activity_log.rb
+++ b/lib/embulk/input/marketo_api/soap/activity_log.rb
@@ -51,14 +51,13 @@ module Embulk
             }
             request[:start_position][:offset] = options[:offset] if options[:offset]
 
-            Embulk.logger.info "Fetching from '#{from}' to '#{to}'..."
             fetch(request, options, &block)
           end
 
           def fetch(request, options={}, &block)
             response = savon_call(:get_lead_changes, {message: request}, options)
             remaining = response.xpath('//remainingCount').text.to_i
-            Embulk.logger.info "Remaining records: #{remaining}"
+            Embulk.logger.info "Remaining #{remaining} records for this range: from '#{request[:start_position][:oldest_created_at]}' to '#{request[:start_position][:latest_created_at]}'."
 
             activities = response.xpath('//leadChangeRecord')
 

--- a/lib/embulk/input/marketo_api/soap/base.rb
+++ b/lib/embulk/input/marketo_api/soap/base.rb
@@ -29,7 +29,7 @@ module Embulk
             # NOTE: Do not memoize this to use always fresh signature (avoid 20016 error)
             # ref. https://jira.talendforge.org/secure/attachmentzip/unzip/167201/49761%5B1%5D/Marketo%20Enterprise%20API%202%200.pdf (41 page)
             Savon.client(
-              log: true,
+              log: false,
               logger: Embulk.logger,
               wsdl: wsdl,
               soap_header: headers,

--- a/lib/embulk/input/marketo_api/soap/base.rb
+++ b/lib/embulk/input/marketo_api/soap/base.rb
@@ -50,6 +50,7 @@ module Embulk
               config.rescues = [StandardError, Timeout::Error]
               config.logger = Embulk.logger
               config.log_level = nil
+              config.raise_original_error = true
             end
           end
 

--- a/lib/embulk/input/marketo_api/soap/lead.rb
+++ b/lib/embulk/input/marketo_api/soap/lead.rb
@@ -47,11 +47,11 @@ module Embulk
           def fetch(request = {}, retry_options, &block)
             start = Time.now
             response = savon_call(:get_multiple_leads, {message: request}, retry_options)
-            Embulk.logger.info "Fetched in #{Time.now - start} seconds"
+            Embulk.logger.debug "Fetched in #{Time.now - start} seconds"
 
             records = response.xpath('//leadRecordList/leadRecord')
             remaining = response.xpath('//remainingCount').text.to_i
-            Embulk.logger.info "Fetched records in the range: #{records.size}"
+            Embulk.logger.debug "Fetched records in the range: #{records.size}"
             Embulk.logger.info "Remaining records in the range: #{remaining}"
 
             records.each do |lead|

--- a/test/embulk/input/marketo_api/soap/test_base.rb
+++ b/test/embulk/input/marketo_api/soap/test_base.rb
@@ -22,7 +22,7 @@ module Embulk
 
               mock(Embulk.logger).warn(/Retrying/).times(retry_options[:retry_limit])
 
-              assert_raise(PerfectRetry::TooManyRetry) do
+              assert_raise(::Timeout::Error) do
                 soap.send(:savon_call, :timeout_test, {}, retry_options)
               end
             end


### PR DESCRIPTION
- Raise original error instead of TooManyRetry error
- Reduce redundant log
  - Don't show Savon request log
  - Some trivial information log level to `debug` from `info`
