### PR TITLE
Generate config_diff even if no records found

### DIFF
--- a/lib/embulk/input/marketo/activity_log.rb
+++ b/lib/embulk/input/marketo/activity_log.rb
@@ -78,8 +78,13 @@ module Embulk
           page_builder.finish
 
           task_report = {}
-          if !preview? && latest_updated_at
-            task_report = {from_datetime: latest_updated_at}
+          if !preview?
+            from_datetime = latest_updated_at || task[:from_datetime]
+            if from_datetime
+              task_report = {
+                from_datetime: from_datetime
+              }
+            end
           end
 
           return task_report

--- a/test/activity_log_fixtures.rb
+++ b/test/activity_log_fixtures.rb
@@ -61,6 +61,20 @@ XML
 XML
   end
 
+  def xml_ac_response_no_record
+    activity_log_xml <<-XML
+<returnCount>0</returnCount>
+<remainingCount>0</remainingCount>
+<newStartPosition>
+  <latestCreatedAt>2015-07-14T09:13:10+09:00</latestCreatedAt>
+  <oldestCreatedAt>2015-07-14T09:13:13+09:00</oldestCreatedAt>
+  <activityCreatedAt xsi:nil="true"/>
+  <offset>offset</offset>
+</newStartPosition>
+<leadChangeRecordList>
+</leadChangeRecordList>
+    XML
+  end
 
   def xml_ac_response
     activity_log_xml <<XML

--- a/test/embulk/input/marketo/test_activity_log.rb
+++ b/test/embulk/input/marketo/test_activity_log.rb
@@ -337,6 +337,28 @@ module Embulk
             end
           end
 
+          def test_task_report
+            stub(@plugin).preview? { false }
+
+            any_instance_of(Savon::Client) do |klass|
+              mock(klass).call(:get_lead_changes, anything) do
+                savon_response(xml_ac_response_no_record)
+              end
+            end
+
+            mock(@page_builder).finish
+
+            from_datetime = "1998-11-11"
+            plugin = ActivityLog.new(task().merge(from_datetime: from_datetime), nil, nil, @page_builder)
+            plugin.init
+            actual = plugin.run
+            expected = {
+              from_datetime: from_datetime
+            }
+
+            assert_equal expected, actual
+          end
+
           private
 
           def request


### PR DESCRIPTION
Before this commit, config_diff was generated only some records found.
It is non-friendly for a batch job.