### PR TITLE
Enable tcp keepalive

### DIFF
--- a/embulk-input-marketo.gemspec
+++ b/embulk-input-marketo.gemspec
@@ -13,7 +13,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'savon', ['~> 2.11.1']
-  spec.add_dependency 'httpclient'
+  spec.add_dependency 'httpclient', '>= 2.8.3' # To use tcp_keepalive
+  spec.add_dependency 'httpi', '2.4.2' # To use tcp_keepalive with monky patch (See lib/embulk/input/marketo/base.rb)
   spec.add_dependency 'perfect_retry', ["~> 0.5"]
   spec.add_development_dependency 'embulk', [">= 0.6.13", "< 1.0"]
   spec.add_development_dependency 'bundler', ['~> 1.0']

--- a/lib/embulk/input/marketo_api/soap/base.rb
+++ b/lib/embulk/input/marketo_api/soap/base.rb
@@ -107,7 +107,7 @@ module Embulk
               # unretryable error such as Authentication Failed, Invalid Request, etc.
               raise ConfigError.new soap_message
             end
-          rescue SocketError, ::Java::JavaNet::UnknownHostException, Errno::ECONNREFUSED => e
+          rescue SocketError, ::Java::JavaNet::UnknownHostException, Errno::ECONNREFUSED, HTTPI::SSLError => e
             # maybe endpoint/wsdl domain was wrong
             Embulk.logger.debug "Connection error: endpoint=#{endpoint} wsdl=#{wsdl}"
             raise ConfigError.new "Connection error: #{e.message} (endpoint is '#{endpoint}')"

--- a/lib/embulk/input/marketo_api/soap/base.rb
+++ b/lib/embulk/input/marketo_api/soap/base.rb
@@ -2,6 +2,21 @@ require "savon"
 require "httpclient" # net/http can't verify cert correctly
 require "perfect_retry"
 
+# https://github.com/savonrb/httpi/blob/v2.4.2/lib/httpi/adapter/httpclient.rb
+require "httpi"
+module HTTPI
+  module Adapter
+    class HTTPClient < Base
+      alias_method :original_basic_setup, :basic_setup
+
+      def basic_setup
+        original_basic_setup
+        @client.tcp_keepalive = true
+      end
+    end
+  end
+end
+
 module Embulk
   module Input
     module MarketoApi
@@ -38,6 +53,7 @@ module Embulk
               read_timeout: 90,
               raise_errors: true,
               namespace_identifier: :ns1,
+              adapter: :httpclient,
               env_namespace: 'SOAP-ENV',
             )
           end


### PR DESCRIPTION
Sometimes waiting a response is a long time enough to be killed by NAT.
This PR enables TCP Keepalive to protect a long time session.