### PR TITLE
Fix NullPointerException in buildConfigDiff

### DIFF
--- a/src/test/java/org/embulk/input/marketo/delegate/MarketoBaseBulkExtractInputPluginTest.java
+++ b/src/test/java/org/embulk/input/marketo/delegate/MarketoBaseBulkExtractInputPluginTest.java
@@ -23,6 +23,7 @@ import java.util.Date;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /**
  * Created by khuutantaitai on 10/3/17.
@@ -52,13 +53,33 @@ public class MarketoBaseBulkExtractInputPluginTest
     public void validateInputTaskToDateLessThanJobStartTime()
     {
         Date fromDate = new Date(1504224000000L);
+        DateTime jobStartTime = new DateTime(1506842144000L);
         MarketoBaseBulkExtractInputPlugin.PluginTask pluginTask = Mockito.mock(MarketoBaseBulkExtractInputPlugin.PluginTask.class);
         Mockito.when(pluginTask.getFromDate()).thenReturn(fromDate);
+        Mockito.when(pluginTask.getJobStartTime()).thenReturn(jobStartTime);
         Mockito.when(pluginTask.getFetchDays()).thenReturn(7);
         baseBulkExtractInputPlugin.validateInputTask(pluginTask);
         ArgumentCaptor<Optional<Date>> argumentCaptor = ArgumentCaptor.forClass(Optional.class);
         Mockito.verify(pluginTask, Mockito.times(1)).setToDate(argumentCaptor.capture());
         assertEquals(1504828800000L, argumentCaptor.getValue().get().getTime());
+    }
+
+    @Test()
+    public void validateInputTaskFromDateMoreThanJobStartTime()
+    {
+        Date fromDate = new Date(1507619744000L);
+        DateTime jobStartTime = new DateTime(1506842144000L);
+        MarketoBaseBulkExtractInputPlugin.PluginTask pluginTask = Mockito.mock(MarketoBaseBulkExtractInputPlugin.PluginTask.class);
+        Mockito.when(pluginTask.getFromDate()).thenReturn(fromDate);
+        Mockito.when(pluginTask.getJobStartTime()).thenReturn(jobStartTime);
+
+        try {
+            baseBulkExtractInputPlugin.validateInputTask(pluginTask);
+        }
+        catch (ConfigException ex) {
+            return;
+        }
+        fail();
     }
 
     @Test()
@@ -73,7 +94,7 @@ public class MarketoBaseBulkExtractInputPluginTest
         baseBulkExtractInputPlugin.validateInputTask(pluginTask);
         ArgumentCaptor<Optional<Date>> toDateArgumentCaptor = ArgumentCaptor.forClass(Optional.class);
         Mockito.verify(pluginTask, Mockito.times(1)).setToDate(toDateArgumentCaptor.capture());
-        assertEquals(jobStartTime.minusHours(1).getMillis(), toDateArgumentCaptor.getValue().get().getTime());
+        assertEquals(jobStartTime.getMillis(), toDateArgumentCaptor.getValue().get().getTime());
     }
 
     @Test

--- a/src/test/java/org/embulk/input/marketo/rest/MarketoRestClientTest.java
+++ b/src/test/java/org/embulk/input/marketo/rest/MarketoRestClientTest.java
@@ -139,20 +139,6 @@ public class MarketoRestClientTest
         Assert.fail();
     }
 
-    @Test()
-    public void createLeadBulkExtractWithParseError() throws Exception
-    {
-        Mockito.doThrow(JsonProcessingException.class).when(marketoRestClient).doPost(Mockito.eq(END_POINT + MarketoRESTEndpoint.CREATE_LEAD_EXTRACT.getEndpoint()), Mockito.isNull(Map.class), Mockito.isNull(ImmutableListMultimap.class), Mockito.anyString(), Mockito.any(MarketoResponseJetty92EntityReader.class));
-        String filterField = "filterField";
-        try {
-            marketoRestClient.createLeadBulkExtract(new Date(), new Date(), Arrays.asList("extract_field1", "extract_field2"), filterField);
-        }
-        catch (DataException ex) {
-            return;
-        }
-        Assert.fail();
-    }
-
     @Test
     public void createActitvityExtract() throws Exception
     {


### PR DESCRIPTION
Fix NullPointerException in buildConfigDiff when there is no data
returned.
Make toDate equal job start time when it's bigger than jobStartTime.toDate was previously capped to be smaller then job start time minus 1
hours.
Add validation to make sure from_date must be smaller than current time

### Are all connections created by the plugin secure?

- [x] Does it opt secure communication standard? Such as HTTPS, SSH, SFTP, SMTP STARTTLS. If not check with CISO to decide we can deploy the plugin.
- [x] Does support both authentication and encryption appropriately? Such as: "just encrypting without authentication" that is insecure.

### Does the plugin connect only to its expected external site which the customer explicitly set in their config file?

- [x] Does NOT connect unexpected external site and our internal endpoints? Such as: “v3/job/:id/set_started” callback endpoint.

### Does NOT the plugin persist any customers' private information? Identify the private information beforehand.

- [x] Does NOT include them in (temporary) files?
- [x] Does NOT include them in log messages and exception messages?

### What kind of environments does the plugin interact with?

- [x] Does NOT execute any shell command?
- [x] Does NOT read any files on the running instance? Such as: "/etc/passwords". It’s ok to read temporary files that the plugin wrote.
- [x] Does use to create temporary files by spi.TempFileSpace utility to avoid the conflict of the file names.
- [x] Does NOT get environment variables or JVM system properties at runtime? Such as AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY in environment variables

### Does NOT the plugin use insecure libraries?

- [x] Line up all depending library so that we can identify the impact of security incident of those library if any.
- [x] Check libraries usage of the plugin; all security check list must apply to the library usages. Such as "Are all connections created by the library secure?"

### Does NOT the plugin source code repository contain kinds of credentials

- [x] API keys
- [x] Passwords

### Make sure to free up all resources allocated during Embulk transaction “committing” or “rolling back”or before.

- [x] Network (connections, pooled connections)
- [x] Memory (cache in static variables)
- [x] File (temporary files)
- [x] CPU (threads, processes)