### PR TITLE
Fix infinite loop in non bulk extract target

### DIFF
--- a/src/main/java/org/embulk/input/marketo/rest/MarketoBaseRestClient.java
+++ b/src/main/java/org/embulk/input/marketo/rest/MarketoBaseRestClient.java
@@ -171,7 +171,7 @@ public class MarketoBaseRestClient implements AutoCloseable
                     }
                 }
                 if (contentProvider != null) {
-                    request.content(contentProvider, APPLICATION_JSON);
+                    request.content(contentProvider);
                 }
                 request.send(responseListener);
             }

--- a/src/test/java/org/embulk/input/marketo/rest/MarketoBaseRestClientTest.java
+++ b/src/test/java/org/embulk/input/marketo/rest/MarketoBaseRestClientTest.java
@@ -153,7 +153,7 @@ public class MarketoBaseRestClientTest
         Mockito.verify(mockRequest, Mockito.times(1)).header(Mockito.eq("testHeader1"), Mockito.eq("testHeaderValue1"));
         Mockito.verify(mockRequest, Mockito.times(1)).header(Mockito.eq("Authorization"), Mockito.eq("Bearer access_token"));
         Mockito.verify(mockRequest, Mockito.times(1)).param(Mockito.eq("param"), Mockito.eq("param1"));
-        Mockito.verify(mockRequest, Mockito.times(1)).content(Mockito.eq(contentProvider), Mockito.eq("application/json"));
+        Mockito.verify(mockRequest, Mockito.times(1)).content(Mockito.eq(contentProvider));
     }
 
     @Test


### PR DESCRIPTION
Redundant content type are set and force all post request to use
application/json data type which cause Marketo to ignore nextPageToken
parameter and return the same token

### Are all connections created by the plugin secure?

- [x] Does it opt secure communication standard? Such as HTTPS, SSH, SFTP, SMTP STARTTLS. If not check with CISO to decide we can deploy the plugin.
- [x] Does support both authentication and encryption appropriately? Such as: "just encrypting without authentication" that is insecure.

### Does the plugin connect only to its expected external site which the customer explicitly set in their config file?

- [x] Does NOT connect unexpected external site and our internal endpoints? Such as: “v3/job/:id/set_started” callback endpoint.

### Does NOT the plugin persist any customers' private information? Identify the private information beforehand.

- [x] Does NOT include them in (temporary) files?
- [x] Does NOT include them in log messages and exception messages?

### What kind of environments does the plugin interact with?

- [x] Does NOT execute any shell command?
- [x] Does NOT read any files on the running instance? Such as: "/etc/passwords". It’s ok to read temporary files that the plugin wrote.
- [x] Does use to create temporary files by spi.TempFileSpace utility to avoid the conflict of the file names.
- [x] Does NOT get environment variables or JVM system properties at runtime? Such as AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY in environment variables

### Does NOT the plugin use insecure libraries?

- [x] Line up all depending library so that we can identify the impact of security incident of those library if any.
- [x] Check libraries usage of the plugin; all security check list must apply to the library usages. Such as "Are all connections created by the library secure?"

### Does NOT the plugin source code repository contain kinds of credentials

- [x] API keys
- [x] Passwords

### Make sure to free up all resources allocated during Embulk transaction “committing” or “rolling back”or before.

- [x] Network (connections, pooled connections)
- [x] Memory (cache in static variables)
- [x] File (temporary files)
- [x] CPU (threads, processes)