### PR TITLE
Fix incorrect retry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,12 +43,13 @@ checkstyle {
     toolVersion = '6.14.1'
 }
 checkstyleMain {
+    exclude '**/**/CsvTokenizer*'
     configFile = file("${project.rootDir}/config/checkstyle/default.xml")
-    ignoreFailures = true
+    ignoreFailures = false
 }
 checkstyleTest {
     configFile = file("${project.rootDir}/config/checkstyle/default.xml")
-    ignoreFailures = true
+    ignoreFailures = false
 }
 task checkstyle(type: Checkstyle) {
     classpath = sourceSets.main.output + sourceSets.test.output

--- a/src/test/java/org/embulk/input/marketo/TestMarketoInputPlugin.java
+++ b/src/test/java/org/embulk/input/marketo/TestMarketoInputPlugin.java
@@ -1,5 +1,0 @@
-package org.embulk.input.marketo;
-
-public class TestMarketoInputPlugin
-{
-}


### PR DESCRIPTION
### Are all connections created by the plugin secure?

- [x] Does it opt secure communication standard? Such as HTTPS, SSH, SFTP, SMTP STARTTLS. If not check with CISO to decide we can deploy the plugin.
- [x] Does support both authentication and encryption appropriately? Such as: "just encrypting without authentication" that is insecure.

### Does the plugin connect only to its expected external site which the customer explicitly set in their config file?

- [x] Does NOT connect unexpected external site and our internal endpoints? Such as: “v3/job/:id/set_started” callback endpoint.

### Does NOT the plugin persist any customers' private information? Identify the private information beforehand.

- [x] Does NOT include them in (temporary) files?
- [x] Does NOT include them in log messages and exception messages?

### What kind of environments does the plugin interact with?

- [x] Does NOT execute any shell command?
- [x] Does NOT read any files on the running instance? Such as: "/etc/passwords". It’s ok to read temporary files that the plugin wrote.
- [x] Does use to create temporary files by spi.TempFileSpace utility to avoid the conflict of the file names.
- [x] Does NOT get environment variables or JVM system properties at runtime? Such as AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY in environment variables

### Does NOT the plugin use insecure libraries?

- [x] Line up all depending library so that we can identify the impact of security incident of those library if any.
- [x] Check libraries usage of the plugin; all security check list must apply to the library usages. Such as "Are all connections created by the library secure?"

### Does NOT the plugin source code repository contain kinds of credentials

- [x] API keys
- [x] Passwords

### Make sure to free up all resources allocated during Embulk transaction “committing” or “rolling back”or before.

- [x] Network (connections, pooled connections)
- [x] Memory (cache in static variables)
- [x] File (temporary files)
- [x] CPU (threads, processes)