### PR TITLE
Fix wrapped TimeoutException not retried

### DIFF
--- a/src/main/java/org/embulk/input/marketo/MarketoInputPluginDelegate.java
+++ b/src/main/java/org/embulk/input/marketo/MarketoInputPluginDelegate.java
@@ -30,18 +30,6 @@ public class MarketoInputPluginDelegate
         @Config("target")
         Target getTarget();
 
-        @Config("maximum_retries")
-        @ConfigDefault("3")
-        Integer getMaximumRetries();
-
-        @Config("initial_retry_interval_milis")
-        @ConfigDefault("20000")
-        Integer getInitialRetryIntervalMilis();
-
-        @Config("maximum_retries_interval_milis")
-        @ConfigDefault("120000")
-        Integer getMaximumRetriesIntervalMilis();
-
         //We don't need to let the internal plugin know that it being dispatched and force it to set require field optional
         //We will hide the real from_date, and set it when validating task
         @Config("hidden_from_date")

--- a/src/main/java/org/embulk/input/marketo/delegate/MarketoBaseInputPluginDelegate.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/MarketoBaseInputPluginDelegate.java
@@ -36,7 +36,7 @@ public abstract class MarketoBaseInputPluginDelegate<T extends MarketoBaseInputP
             extends RestClientInputTaskBase, MarketoRestClient.PluginTask
     {
         @Config("maximum_retries")
-        @ConfigDefault("3")
+        @ConfigDefault("7")
         Integer getMaximumRetries();
 
         @Config("initial_retry_interval_milis")

--- a/src/main/java/org/embulk/input/marketo/rest/MarketoBaseRestClient.java
+++ b/src/main/java/org/embulk/input/marketo/rest/MarketoBaseRestClient.java
@@ -33,7 +33,7 @@ import static com.fasterxml.jackson.core.JsonParser.Feature.ALLOW_UNQUOTED_CONTR
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 
 /**
- * Marketo base rest client that provide
+ * Marketo base rest client
  * Created by tai.khuu on 9/7/17.
  */
 public class MarketoBaseRestClient implements AutoCloseable
@@ -44,8 +44,6 @@ public class MarketoBaseRestClient implements AutoCloseable
 
     private static final String AUTHORIZATION_HEADER = "Authorization";
 
-    protected static final long READ_TIMEOUT_MILLIS = 30000;
-
     private String identityEndPoint;
 
     private String clientId;
@@ -54,19 +52,22 @@ public class MarketoBaseRestClient implements AutoCloseable
 
     private String accessToken;
 
-    private int marketoLimitIntervalMilis;
+    private int marketoLimitIntervalMillis;
 
     private Jetty92RetryHelper retryHelper;
 
+    protected long readTimeoutMillis;
+
     protected static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().configure(FAIL_ON_UNKNOWN_PROPERTIES, false).configure(ALLOW_UNQUOTED_CONTROL_CHARS, false);
 
-    MarketoBaseRestClient(String identityEndPoint, String clientId, String clientSecret, int marketoLimitIntervalMilis, Jetty92RetryHelper retryHelper)
+    MarketoBaseRestClient(String identityEndPoint, String clientId, String clientSecret, int marketoLimitIntervalMillis, long readTimeoutMillis, Jetty92RetryHelper retryHelper)
     {
         this.identityEndPoint = identityEndPoint;
         this.clientId = clientId;
         this.clientSecret = clientSecret;
+        this.readTimeoutMillis = readTimeoutMillis;
         this.retryHelper = retryHelper;
-        this.marketoLimitIntervalMilis = marketoLimitIntervalMilis;
+        this.marketoLimitIntervalMillis = marketoLimitIntervalMillis;
     }
 
     private void renewAccessToken()
@@ -93,7 +94,7 @@ public class MarketoBaseRestClient implements AutoCloseable
         params.put("client_id", clientId);
         params.put("client_secret", clientSecret);
         params.put("grant_type", "client_credentials");
-        String response = retryHelper.requestWithRetry(new StringJetty92ResponseEntityReader(READ_TIMEOUT_MILLIS), new Jetty92SingleRequester()
+        String response = retryHelper.requestWithRetry(new StringJetty92ResponseEntityReader(readTimeoutMillis), new Jetty92SingleRequester()
         {
             @Override
             public void requestOnce(HttpClient client, Response.Listener responseListener)
@@ -116,7 +117,7 @@ public class MarketoBaseRestClient implements AutoCloseable
             @Override
             protected boolean isExceptionToRetry(Exception exception)
             {
-                if (exception instanceof ExecutionException) {
+                if (exception instanceof ExecutionException || (exception instanceof IOException && exception.getCause() != null)) {
                     return this.toRetry((Exception) exception.getCause());
                 }
                 return exception instanceof TimeoutException || exception instanceof SocketTimeoutException || exception instanceof EOFException || super.isExceptionToRetry(exception);
@@ -197,7 +198,7 @@ public class MarketoBaseRestClient implements AutoCloseable
             @Override
             protected boolean isExceptionToRetry(Exception exception)
             {
-                if (exception instanceof ExecutionException) {
+                if (exception instanceof ExecutionException || (exception instanceof IOException && exception.getCause() != null)) {
                     return this.toRetry((Exception) exception.getCause());
                 }
                 if (exception instanceof MarketoAPIException) {
@@ -212,7 +213,7 @@ public class MarketoBaseRestClient implements AutoCloseable
                             return true;
                         case "606":
                             try {
-                                Thread.sleep(marketoLimitIntervalMilis);
+                                Thread.sleep(marketoLimitIntervalMillis);
                             }
                             catch (InterruptedException e) {
                                 LOGGER.error("Encounter exception when waiting for interval limit", e);

--- a/src/main/java/org/embulk/input/marketo/rest/MarketoBaseRestClient.java
+++ b/src/main/java/org/embulk/input/marketo/rest/MarketoBaseRestClient.java
@@ -117,10 +117,14 @@ public class MarketoBaseRestClient implements AutoCloseable
             @Override
             protected boolean isExceptionToRetry(Exception exception)
             {
+                if (exception instanceof TimeoutException || exception instanceof SocketTimeoutException || exception instanceof EOFException || super.isExceptionToRetry(exception)) {
+                    return true;
+                }
+                // unwrap
                 if (exception instanceof ExecutionException || (exception instanceof IOException && exception.getCause() != null)) {
                     return this.toRetry((Exception) exception.getCause());
                 }
-                return exception instanceof TimeoutException || exception instanceof SocketTimeoutException || exception instanceof EOFException || super.isExceptionToRetry(exception);
+                return false;
             }
         });
 
@@ -198,6 +202,9 @@ public class MarketoBaseRestClient implements AutoCloseable
             @Override
             protected boolean isExceptionToRetry(Exception exception)
             {
+                if (exception instanceof EOFException || exception instanceof TimeoutException || exception instanceof SocketTimeoutException || super.isExceptionToRetry(exception)) {
+                    return true;
+                }
                 if (exception instanceof ExecutionException || (exception instanceof IOException && exception.getCause() != null)) {
                     return this.toRetry((Exception) exception.getCause());
                 }
@@ -226,7 +233,7 @@ public class MarketoBaseRestClient implements AutoCloseable
                             return false;
                     }
                 }
-                return exception instanceof EOFException || exception instanceof TimeoutException || exception instanceof SocketTimeoutException || super.isExceptionToRetry(exception);
+                return false;
             }
         });
     }


### PR DESCRIPTION
* Fix when TimeoutException is wrapped in IOException it won't get retried.
* Increase read timeout to 60 seconds
* Make read timeout configurable
* Increase max_retry times to 7
* Remove uneccessary configuration in delegate.
* Update unit tests

### Are all connections created by the plugin secure?

- [ ] Does it opt secure communication standard? Such as HTTPS, SSH, SFTP, SMTP STARTTLS. If not check with CISO to decide we can deploy the plugin.
- [ ] Does support both authentication and encryption appropriately? Such as: "just encrypting without authentication" that is insecure.

### Does the plugin connect only to its expected external site which the customer explicitly set in their config file?

- [ ] Does NOT connect unexpected external site and our internal endpoints? Such as: “v3/job/:id/set_started” callback endpoint.

### Does NOT the plugin persist any customers' private information? Identify the private information beforehand.

- [ ] Does NOT include them in (temporary) files?
- [ ] Does NOT include them in log messages and exception messages?

### What kind of environments does the plugin interact with?

- [ ] Does NOT execute any shell command?
- [ ] Does NOT read any files on the running instance? Such as: "/etc/passwords". It’s ok to read temporary files that the plugin wrote.
- [ ] Does use to create temporary files by spi.TempFileSpace utility to avoid the conflict of the file names.
- [ ] Does NOT get environment variables or JVM system properties at runtime? Such as AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY in environment variables

### Does NOT the plugin use insecure libraries?

- [ ] Line up all depending library so that we can identify the impact of security incident of those library if any.
- [ ] Check libraries usage of the plugin; all security check list must apply to the library usages. Such as "Are all connections created by the library secure?"

### Does NOT the plugin source code repository contain kinds of credentials

- [ ] API keys
- [ ] Passwords

### Make sure to free up all resources allocated during Embulk transaction “committing” or “rolling back”or before.

- [ ] Network (connections, pooled connections)
- [ ] Memory (cache in static variables)
- [ ] File (temporary files)
- [ ] CPU (threads, processes)