### PR TITLE
Add included column option

### DIFF
--- a/src/main/java/org/embulk/input/marketo/MarketoService.java
+++ b/src/main/java/org/embulk/input/marketo/MarketoService.java
@@ -14,10 +14,6 @@ public interface MarketoService
 {
     List<MarketoField> describeLead();
 
-    List<MarketoField> describeLeadByProgram();
-
-    List<MarketoField> describeLeadByLists();
-
     File extractLead(Date startTime, Date endTime, List<String> extractedFields, String filterField, int pollingTimeIntervalSecond, int bulkJobTimeoutSecond);
 
     File extractAllActivity(Date startTime, Date endTime, int pollingTimeIntervalSecond, int bulkJobTimeoutSecond);

--- a/src/main/java/org/embulk/input/marketo/MarketoServiceImpl.java
+++ b/src/main/java/org/embulk/input/marketo/MarketoServiceImpl.java
@@ -185,22 +185,6 @@ public class MarketoServiceImpl implements MarketoService
         return marketoRestClient.describeLead();
     }
 
-    @Override
-    public List<MarketoField> describeLeadByProgram()
-    {
-        List<MarketoField> columns = marketoRestClient.describeLead();
-        columns.add(new MarketoField(MarketoUtils.PROGRAM_ID_COLUMN_NAME, MarketoField.MarketoDataType.STRING));
-        return columns;
-    }
-
-    @Override
-    public List<MarketoField> describeLeadByLists()
-    {
-        List<MarketoField> columns = marketoRestClient.describeLead();
-        columns.add(new MarketoField(MarketoUtils.LIST_ID_COLUMN_NAME, MarketoField.MarketoDataType.STRING));
-        return columns;
-    }
-
     private static class DownloadBulkExtractException extends Exception
     {
         private final long byteWritten;

--- a/src/main/java/org/embulk/input/marketo/MarketoUtils.java
+++ b/src/main/java/org/embulk/input/marketo/MarketoUtils.java
@@ -3,6 +3,9 @@ package org.embulk.input.marketo;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.embulk.base.restclient.ServiceResponseMapper;
 import org.embulk.base.restclient.jackson.JacksonServiceRecord;
@@ -18,11 +21,7 @@ import org.slf4j.Logger;
 
 import javax.annotation.Nullable;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Created by tai.khuu on 9/18/17.

--- a/src/main/java/org/embulk/input/marketo/MarketoUtils.java
+++ b/src/main/java/org/embulk/input/marketo/MarketoUtils.java
@@ -3,9 +3,6 @@ package org.embulk.input.marketo;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Function;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Collections2;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.embulk.base.restclient.ServiceResponseMapper;
 import org.embulk.base.restclient.jackson.JacksonServiceRecord;
@@ -21,7 +18,11 @@ import org.slf4j.Logger;
 
 import javax.annotation.Nullable;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Set;
 
 /**
  * Created by tai.khuu on 9/18/17.

--- a/src/main/java/org/embulk/input/marketo/delegate/LeadBulkExtractInputPlugin.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/LeadBulkExtractInputPlugin.java
@@ -7,8 +7,6 @@ import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.input.marketo.MarketoService;
 import org.embulk.input.marketo.MarketoServiceImpl;
-import org.embulk.input.marketo.MarketoUtils;
-import org.embulk.input.marketo.model.MarketoField;
 import org.embulk.input.marketo.rest.MarketoRestClient;
 import org.embulk.spi.DataException;
 import org.embulk.spi.Exec;
@@ -29,7 +27,7 @@ public class LeadBulkExtractInputPlugin extends MarketoBaseBulkExtractInputPlugi
 
     private static final String UPDATED_AT = "updatedAt";
 
-    public interface PluginTask extends MarketoBaseBulkExtractInputPlugin.PluginTask
+    public interface PluginTask extends MarketoBaseBulkExtractInputPlugin.PluginTask, LeadServiceResponseMapperBuilder.PluginTask
     {
         @Config("use_updated_at")
         @ConfigDefault("false")
@@ -63,9 +61,8 @@ public class LeadBulkExtractInputPlugin extends MarketoBaseBulkExtractInputPlugi
     {
         try (MarketoRestClient marketoRestClient = createMarketoRestClient(task)) {
             MarketoService marketoService = new MarketoServiceImpl(marketoRestClient);
-            List<MarketoField> columns = marketoService.describeLead();
-            task.setExtractedFields(MarketoUtils.getFieldNameFromMarketoFields(columns));
-            return MarketoUtils.buildDynamicResponseMapper(task.getSchemaColumnPrefix(), columns);
+            LeadServiceResponseMapperBuilder<PluginTask> leadServiceResponseMapperBuilder = new LeadServiceResponseMapperBuilder<>(task, marketoService);
+            return leadServiceResponseMapperBuilder.buildServiceResponseMapper(task);
         }
     }
 }

--- a/src/main/java/org/embulk/input/marketo/delegate/LeadServiceResponseMapperBuilder.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/LeadServiceResponseMapperBuilder.java
@@ -1,0 +1,85 @@
+package org.embulk.input.marketo.delegate;
+
+import com.google.common.base.Optional;
+import org.embulk.base.restclient.ServiceResponseMapper;
+import org.embulk.base.restclient.ServiceResponseMapperBuildable;
+import org.embulk.base.restclient.record.ValueLocator;
+import org.embulk.config.Config;
+import org.embulk.config.ConfigDefault;
+import org.embulk.input.marketo.MarketoService;
+import org.embulk.input.marketo.MarketoUtils;
+import org.embulk.input.marketo.model.MarketoField;
+import org.embulk.spi.Exec;
+import org.slf4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by tai.khuu on 5/21/18.
+ */
+public class LeadServiceResponseMapperBuilder<T extends LeadServiceResponseMapperBuilder.PluginTask> implements ServiceResponseMapperBuildable<T>
+{
+    private static final Logger LOGGER = Exec.getLogger(LeadServiceResponseMapperBuilder.class);
+    private MarketoService marketoService;
+
+    private T pluginTask;
+
+    public interface PluginTask extends MarketoBaseInputPluginDelegate.PluginTask
+    {
+        @Config("included_fields")
+        @ConfigDefault("null")
+        Optional<List<String>> getIncludedLeadFields();
+
+        @Config("extracted_fields")
+        @ConfigDefault("[]")
+        List<String> getExtractedFields();
+
+        void setExtractedFields(List<String> extractedFields);
+    }
+
+    public LeadServiceResponseMapperBuilder(T task, MarketoService marketoService)
+    {
+        this.pluginTask = task;
+        this.marketoService = marketoService;
+    }
+
+    protected List<MarketoField> getLeadColumns()
+    {
+        List<MarketoField> columns = marketoService.describeLead();
+        if (pluginTask.getIncludedLeadFields().isPresent() && !pluginTask.getIncludedLeadFields().get().isEmpty()) {
+            List<MarketoField> filteredColumns = new ArrayList<>();
+            List<String> includedFields = pluginTask.getIncludedLeadFields().get();
+            for (String fieldName : includedFields) {
+                Optional<MarketoField> includedField = lookupFieldIgnoreCase(columns, fieldName);
+                if (includedField.isPresent()) {
+                    filteredColumns.add(includedField.get());
+                }
+                else {
+                    LOGGER.warn("Included field [{}] not found in Marketo lead field", fieldName);
+                }
+            }
+            columns = filteredColumns;
+        }
+        LOGGER.info("Included Fields option is set, included columns: [{}]", columns);
+        return columns;
+    }
+
+    private static Optional<MarketoField> lookupFieldIgnoreCase(List<MarketoField> inputList, String lookupFieldName)
+    {
+        for (MarketoField marketoField : inputList) {
+            if (marketoField.getName().equalsIgnoreCase(lookupFieldName)) {
+                return Optional.of(marketoField);
+            }
+        }
+        return Optional.absent();
+    }
+
+    @Override
+    public ServiceResponseMapper<? extends ValueLocator> buildServiceResponseMapper(T task)
+    {
+        List<MarketoField> leadColumns = getLeadColumns();
+        pluginTask.setExtractedFields(MarketoUtils.getFieldNameFromMarketoFields(leadColumns));
+        return MarketoUtils.buildDynamicResponseMapper(pluginTask.getSchemaColumnPrefix(), leadColumns);
+    }
+}

--- a/src/main/java/org/embulk/input/marketo/delegate/LeadServiceResponseMapperBuilder.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/LeadServiceResponseMapperBuilder.java
@@ -60,8 +60,8 @@ public class LeadServiceResponseMapperBuilder<T extends LeadServiceResponseMappe
                 }
             }
             columns = filteredColumns;
+            LOGGER.info("Included Fields option is set, included columns: [{}]", columns);
         }
-        LOGGER.info("Included Fields option is set, included columns: [{}]", columns);
         return columns;
     }
 

--- a/src/main/java/org/embulk/input/marketo/delegate/LeadWithListInputPlugin.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/LeadWithListInputPlugin.java
@@ -10,6 +10,7 @@ import org.embulk.input.marketo.MarketoUtils;
 import org.embulk.input.marketo.model.MarketoField;
 import org.embulk.input.marketo.rest.MarketoRestClient;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
@@ -18,7 +19,7 @@ import java.util.List;
  */
 public class LeadWithListInputPlugin extends MarketoBaseInputPluginDelegate<LeadWithListInputPlugin.PluginTask>
 {
-    public interface PluginTask extends MarketoBaseInputPluginDelegate.PluginTask
+    public interface PluginTask extends MarketoBaseInputPluginDelegate.PluginTask, LeadServiceResponseMapperBuilder.PluginTask
     {
     }
 
@@ -29,7 +30,9 @@ public class LeadWithListInputPlugin extends MarketoBaseInputPluginDelegate<Lead
     @Override
     protected Iterator<ServiceRecord> getServiceRecords(MarketoService marketoService, PluginTask task)
     {
-        return FluentIterable.from(marketoService.getAllListLead(task.getExtractedFields())).transform(MarketoUtils.TRANSFORM_OBJECT_TO_JACKSON_SERVICE_RECORD_FUNCTION).iterator();
+        List<String> extractedFields = task.getExtractedFields();
+        extractedFields.remove(MarketoUtils.LIST_ID_COLUMN_NAME);
+        return FluentIterable.from(marketoService.getAllListLead(extractedFields)).transform(MarketoUtils.TRANSFORM_OBJECT_TO_JACKSON_SERVICE_RECORD_FUNCTION).iterator();
     }
 
     @Override
@@ -37,9 +40,25 @@ public class LeadWithListInputPlugin extends MarketoBaseInputPluginDelegate<Lead
     {
         try (MarketoRestClient marketoRestClient = createMarketoRestClient(task)) {
             MarketoService marketoService = new MarketoServiceImpl(marketoRestClient);
-            List<MarketoField> columns = marketoService.describeLeadByLists();
-            task.setExtractedFields(MarketoUtils.getFieldNameFromMarketoFields(columns, MarketoUtils.LIST_ID_COLUMN_NAME));
-            return MarketoUtils.buildDynamicResponseMapper(task.getSchemaColumnPrefix(), columns);
+            LeadWithListServiceResponseMapper serviceResponseMapper = new LeadWithListServiceResponseMapper(task, marketoService);
+            return serviceResponseMapper.buildServiceResponseMapper(task);
+        }
+    }
+
+    private static class LeadWithListServiceResponseMapper extends LeadServiceResponseMapperBuilder<PluginTask>
+    {
+
+        public LeadWithListServiceResponseMapper(LeadWithListInputPlugin.PluginTask task, MarketoService marketoService)
+        {
+            super(task, marketoService);
+        }
+
+        @Override
+        protected List<MarketoField> getLeadColumns()
+        {
+            List<MarketoField> leadColumns = super.getLeadColumns();
+            leadColumns.add(new MarketoField(MarketoUtils.LIST_ID_COLUMN_NAME, MarketoField.MarketoDataType.STRING));
+            return leadColumns;
         }
     }
 }

--- a/src/main/java/org/embulk/input/marketo/delegate/LeadWithListInputPlugin.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/LeadWithListInputPlugin.java
@@ -31,6 +31,7 @@ public class LeadWithListInputPlugin extends MarketoBaseInputPluginDelegate<Lead
     protected Iterator<ServiceRecord> getServiceRecords(MarketoService marketoService, PluginTask task)
     {
         List<String> extractedFields = task.getExtractedFields();
+        // Remove LIST_ID_COLUMN_NAME when sent fields to Marketo since LIST_ID_COLUMN_NAME are added by plugin code
         extractedFields.remove(MarketoUtils.LIST_ID_COLUMN_NAME);
         return FluentIterable.from(marketoService.getAllListLead(extractedFields)).transform(MarketoUtils.TRANSFORM_OBJECT_TO_JACKSON_SERVICE_RECORD_FUNCTION).iterator();
     }

--- a/src/main/java/org/embulk/input/marketo/delegate/LeadWithProgramInputPlugin.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/LeadWithProgramInputPlugin.java
@@ -18,7 +18,7 @@ import java.util.List;
  */
 public class LeadWithProgramInputPlugin extends MarketoBaseInputPluginDelegate<LeadWithProgramInputPlugin.PluginTask>
 {
-    public interface PluginTask extends MarketoBaseInputPluginDelegate.PluginTask
+    public interface PluginTask extends MarketoBaseInputPluginDelegate.PluginTask, LeadServiceResponseMapperBuilder.PluginTask
     {
     }
 
@@ -26,6 +26,7 @@ public class LeadWithProgramInputPlugin extends MarketoBaseInputPluginDelegate<L
     protected Iterator<ServiceRecord> getServiceRecords(MarketoService marketoService, PluginTask task)
     {
         List<String> fieldNames = task.getExtractedFields();
+        fieldNames.remove(MarketoUtils.PROGRAM_ID_COLUMN_NAME);
         return FluentIterable.from(marketoService.getAllProgramLead(fieldNames)).
                 transform(MarketoUtils.TRANSFORM_OBJECT_TO_JACKSON_SERVICE_RECORD_FUNCTION).iterator();
     }
@@ -35,9 +36,24 @@ public class LeadWithProgramInputPlugin extends MarketoBaseInputPluginDelegate<L
     {
         try (MarketoRestClient marketoRestClient = createMarketoRestClient(task)) {
             MarketoService marketoService = new MarketoServiceImpl(marketoRestClient);
-            List<MarketoField> columns = marketoService.describeLeadByProgram();
-            task.setExtractedFields(MarketoUtils.getFieldNameFromMarketoFields(columns, MarketoUtils.PROGRAM_ID_COLUMN_NAME));
-            return MarketoUtils.buildDynamicResponseMapper(task.getSchemaColumnPrefix(), columns);
+            LeadWithProgramServiceResponseMapper serviceResponseMapper = new LeadWithProgramServiceResponseMapper(task, marketoService);
+            return serviceResponseMapper.buildServiceResponseMapper(task);
+        }
+    }
+
+    private static class LeadWithProgramServiceResponseMapper extends LeadServiceResponseMapperBuilder<PluginTask>
+    {
+        public LeadWithProgramServiceResponseMapper(LeadWithProgramInputPlugin.PluginTask task, MarketoService marketoService)
+        {
+            super(task, marketoService);
+        }
+
+        @Override
+        protected List<MarketoField> getLeadColumns()
+        {
+            List<MarketoField> leadColumns = super.getLeadColumns();
+            leadColumns.add(new MarketoField(MarketoUtils.PROGRAM_ID_COLUMN_NAME, MarketoField.MarketoDataType.STRING));
+            return leadColumns;
         }
     }
 }

--- a/src/main/java/org/embulk/input/marketo/delegate/LeadWithProgramInputPlugin.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/LeadWithProgramInputPlugin.java
@@ -26,6 +26,7 @@ public class LeadWithProgramInputPlugin extends MarketoBaseInputPluginDelegate<L
     protected Iterator<ServiceRecord> getServiceRecords(MarketoService marketoService, PluginTask task)
     {
         List<String> fieldNames = task.getExtractedFields();
+        // Remove PROGRAM_ID_COLUMN_NAME when sent fields to Marketo since PROGRAM_ID_COLUMN_NAME are added by plugin code
         fieldNames.remove(MarketoUtils.PROGRAM_ID_COLUMN_NAME);
         return FluentIterable.from(marketoService.getAllProgramLead(fieldNames)).
                 transform(MarketoUtils.TRANSFORM_OBJECT_TO_JACKSON_SERVICE_RECORD_FUNCTION).iterator();

--- a/src/main/java/org/embulk/input/marketo/delegate/MarketoBaseBulkExtractInputPlugin.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/MarketoBaseBulkExtractInputPlugin.java
@@ -45,7 +45,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Set;
 
 /**
  * Created by tai.khuu on 9/18/17.

--- a/src/main/java/org/embulk/input/marketo/model/MarketoField.java
+++ b/src/main/java/org/embulk/input/marketo/model/MarketoField.java
@@ -114,4 +114,13 @@ public class MarketoField
             return Optional.fromNullable(format);
         }
     }
+
+    @Override
+    public String toString()
+    {
+        return "MarketoField{" +
+                "name='" + name + '\'' +
+                ", marketoDataType=" + marketoDataType +
+                '}';
+    }
 }

--- a/src/test/java/org/embulk/input/marketo/MarketoServiceImplTest.java
+++ b/src/test/java/org/embulk/input/marketo/MarketoServiceImplTest.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.io.ByteStreams;
 import org.embulk.EmbulkTestRuntime;
 import org.embulk.input.marketo.model.BulkExtractRangeHeader;
-import org.embulk.input.marketo.model.MarketoField;
 import org.embulk.input.marketo.rest.MarketoRestClient;
 import org.embulk.input.marketo.rest.RecordPagingIterable;
 import org.junit.Assert;
@@ -134,29 +133,5 @@ public class MarketoServiceImplTest
     {
         marketoService.describeLead();
         Mockito.verify(mockMarketoRestClient, Mockito.times(1)).describeLead();
-    }
-
-    @Test
-    public void describeLeadByProgram() throws Exception
-    {
-        List<MarketoField> marketoFields = new ArrayList<>();
-        Mockito.when(mockMarketoRestClient.describeLead()).thenReturn(marketoFields);
-        marketoService.describeLeadByProgram();
-        Mockito.verify(mockMarketoRestClient, Mockito.times(1)).describeLead();
-        Assert.assertEquals(1, marketoFields.size());
-        Assert.assertEquals("programId", marketoFields.get(0).getName());
-        Assert.assertEquals(MarketoField.MarketoDataType.STRING, marketoFields.get(0).getMarketoDataType());
-    }
-
-    @Test
-    public void describeLeadByLists() throws Exception
-    {
-        List<MarketoField> marketoFields = new ArrayList<>();
-        Mockito.when(mockMarketoRestClient.describeLead()).thenReturn(marketoFields);
-        marketoService.describeLeadByLists();
-        Mockito.verify(mockMarketoRestClient, Mockito.times(1)).describeLead();
-        Assert.assertEquals(1, marketoFields.size());
-        Assert.assertEquals("listId", marketoFields.get(0).getName());
-        Assert.assertEquals(MarketoField.MarketoDataType.STRING, marketoFields.get(0).getMarketoDataType());
     }
 }

--- a/src/test/java/org/embulk/input/marketo/delegate/LeadServiceResponseMapperBuilderTest.java
+++ b/src/test/java/org/embulk/input/marketo/delegate/LeadServiceResponseMapperBuilderTest.java
@@ -1,0 +1,85 @@
+package org.embulk.input.marketo.delegate;
+
+import com.fasterxml.jackson.databind.JavaType;
+import org.embulk.EmbulkTestRuntime;
+import org.embulk.base.restclient.ServiceResponseMapper;
+import org.embulk.base.restclient.record.ValueLocator;
+import org.embulk.config.ConfigLoader;
+import org.embulk.config.ConfigSource;
+import org.embulk.input.marketo.MarketoService;
+import org.embulk.input.marketo.MarketoUtils;
+import org.embulk.input.marketo.model.MarketoField;
+import org.embulk.spi.Schema;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+/**
+ * Created by tai.khuu on 5/24/18.
+ */
+public class LeadServiceResponseMapperBuilderTest
+{
+    private LeadServiceResponseMapperBuilder<LeadServiceResponseMapperBuilder.PluginTask> leadServiceResponseMapperBuilder;
+
+    @Rule
+    public EmbulkTestRuntime embulkTestRuntime = new EmbulkTestRuntime();
+
+    private LeadServiceResponseMapperBuilder.PluginTask pluginTask;
+
+    private ConfigSource configSource;
+
+    private MarketoService marketoService;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        ConfigLoader configLoader = embulkTestRuntime.getExec().getInjector().getInstance(ConfigLoader.class);
+        configSource = configLoader.fromYamlString("--- \n" +
+                "account_id: 389-FLQ-873\n" +
+                "client_id: 87bdd058-12ff-49b8-8d29-c0518669e59a\n" +
+                "client_secret: 2uauyk43zzwjlUZwboZVxQ3SMTHe8ILY\n" +
+                "included_fields: \n" +
+                "  - company\n" +
+                "  - site\n" +
+                "  - billingstreet\n" +
+                "  - billingcity\n" +
+                "  - billingstate\n" +
+                "  - billingcountry\n" +
+                "  - billingpostalCode\n" +
+                "  - website\n" +
+                "  - mainphone\n" +
+                "  - annualrevenue\n" +
+                "  - numberofemployees\n" +
+                "  - industry\n" +
+                "  - siccode\n" +
+                "  - mktoCompanyNotes\n" +
+                "  - externalcompanyId\n" +
+                "  - id\n" +
+                "target: all_lead_with_list_id\n");
+        pluginTask = configSource.loadConfig(LeadServiceResponseMapperBuilder.PluginTask.class);
+        marketoService = Mockito.mock(MarketoService.class);
+        JavaType marketoFieldsType = MarketoUtils.OBJECT_MAPPER.getTypeFactory().constructParametrizedType(List.class, List.class, MarketoField.class);
+        List<MarketoField> marketoFields = MarketoUtils.OBJECT_MAPPER.readValue(this.getClass().getResourceAsStream("/fixtures/lead_describe_marketo_fields_full.json"), marketoFieldsType);
+        Mockito.when(marketoService.describeLead()).thenReturn(marketoFields);
+    }
+
+    @Test
+    public void buildServiceResponseMapper() throws Exception
+    {
+        leadServiceResponseMapperBuilder = new LeadServiceResponseMapperBuilder<>(pluginTask, marketoService);
+        ServiceResponseMapper<? extends ValueLocator> serviceResponseMapper = leadServiceResponseMapperBuilder.buildServiceResponseMapper(pluginTask);
+        Assert.assertFalse(pluginTask.getExtractedFields().isEmpty());
+        Assert.assertEquals(16, pluginTask.getExtractedFields().size());
+        Schema embulkSchema = serviceResponseMapper.getEmbulkSchema();
+        Assert.assertEquals(16, embulkSchema.getColumns().size());
+        Assert.assertEquals("mk_billingStreet", embulkSchema.getColumns().get(2).getName());
+        Assert.assertEquals("mk_company", embulkSchema.getColumn(0).getName());
+        Assert.assertEquals("mk_billingStreet", embulkSchema.getColumn(2).getName());
+        Assert.assertEquals("mk_id", embulkSchema.getColumn(15).getName());
+    }
+
+}

--- a/src/test/java/org/embulk/input/marketo/delegate/LeadServiceResponseMapperBuilderTest.java
+++ b/src/test/java/org/embulk/input/marketo/delegate/LeadServiceResponseMapperBuilderTest.java
@@ -16,6 +16,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -82,4 +84,36 @@ public class LeadServiceResponseMapperBuilderTest
         Assert.assertEquals("mk_id", embulkSchema.getColumn(15).getName());
     }
 
+    @Test
+    public void getLeadColumnsIncludedEmpty() throws IOException
+    {
+        configSource = configSource.set("included_fields", MarketoUtils.OBJECT_MAPPER.readTree("[]"));
+        pluginTask = configSource.loadConfig(LeadServiceResponseMapperBuilder.PluginTask.class);
+        leadServiceResponseMapperBuilder = new LeadServiceResponseMapperBuilder<>(pluginTask, marketoService);
+        List<MarketoField> leadColumns = leadServiceResponseMapperBuilder.getLeadColumns();
+        Assert.assertEquals(129, leadColumns.size());
+    }
+
+    @Test
+    public void getLeadColumnsIncluded1() throws IOException
+    {
+        configSource = configSource.set("included_fields", MarketoUtils.OBJECT_MAPPER.readTree("[\"company\",\"incorrect_value\"]"));
+        pluginTask = configSource.loadConfig(LeadServiceResponseMapperBuilder.PluginTask.class);
+        leadServiceResponseMapperBuilder = new LeadServiceResponseMapperBuilder<>(pluginTask, marketoService);
+        List<MarketoField> leadColumns = leadServiceResponseMapperBuilder.getLeadColumns();
+        Assert.assertEquals(1, leadColumns.size());
+        Assert.assertEquals("company", leadColumns.get(0).getName());
+    }
+
+    @Test
+    public void getLeadColumnsIncluded2() throws IOException
+    {
+        configSource = configSource.set("included_fields", MarketoUtils.OBJECT_MAPPER.readTree("[\"company\",\"incorrect_value\"]"));
+        pluginTask = configSource.loadConfig(LeadServiceResponseMapperBuilder.PluginTask.class);
+        marketoService = Mockito.mock(MarketoService.class);
+        leadServiceResponseMapperBuilder = new LeadServiceResponseMapperBuilder<>(pluginTask, marketoService);
+        Mockito.when(marketoService.describeLead()).thenReturn(new ArrayList<MarketoField>());
+        List<MarketoField> leadColumns = leadServiceResponseMapperBuilder.getLeadColumns();
+        Assert.assertTrue(leadColumns.isEmpty());
+    }
 }

--- a/src/test/java/org/embulk/input/marketo/rest/MarketoRestClientTest.java
+++ b/src/test/java/org/embulk/input/marketo/rest/MarketoRestClientTest.java
@@ -72,7 +72,7 @@ public class MarketoRestClientTest
         configSource.set("max_return", 2);
         MarketoRestClient.PluginTask task = configSource.loadConfig(MarketoRestClient.PluginTask.class);
         mockRetryHelper = Mockito.mock(Jetty92RetryHelper.class);
-        MarketoRestClient realRestClient = new MarketoRestClient(task, mockRetryHelper);
+        MarketoRestClient realRestClient = new MarketoRestClient(task);
         marketoRestClient = Mockito.spy(realRestClient);
     }
 


### PR DESCRIPTION
Move all lead ServiceResponseMapper logic to 1 class
Move preview record limit to it right place
Add included column option

### Are all connections created by the plugin secure?

- [x] Does it opt secure communication standard? Such as HTTPS, SSH, SFTP, SMTP STARTTLS. If not check with CISO to decide we can deploy the plugin.
- [x] Does support both authentication and encryption appropriately? Such as: "just encrypting without authentication" that is insecure.

### Does the plugin connect only to its expected external site which the customer explicitly set in their config file?

- [x] Does NOT connect unexpected external site and our internal endpoints? Such as: “v3/job/:id/set_started” callback endpoint.

### Does NOT the plugin persist any customers' private information? Identify the private information beforehand.

- [x] Does NOT include them in (temporary) files?
- [x] Does NOT include them in log messages and exception messages?

### What kind of environments does the plugin interact with?

- [x] Does NOT execute any shell command?
- [x] Does NOT read any files on the running instance? Such as: "/etc/passwords". It’s ok to read temporary files that the plugin wrote.
- [x] Does use to create temporary files by spi.TempFileSpace utility to avoid the conflict of the file names.
- [x] Does NOT get environment variables or JVM system properties at runtime? Such as AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY in environment variables

### Does NOT the plugin use insecure libraries?

- [x] Line up all depending library so that we can identify the impact of security incident of those library if any.
- [x] Check libraries usage of the plugin; all security check list must apply to the library usages. Such as "Are all connections created by the library secure?"

### Does NOT the plugin source code repository contain kinds of credentials

- [x] API keys
- [x] Passwords

### Make sure to free up all resources allocated during Embulk transaction “committing” or “rolling back”or before.

- [x] Network (connections, pooled connections)
- [x] Memory (cache in static variables)
- [x] File (temporary files)
- [x] CPU (threads, processes)