### PR TITLE
Improve error handler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ jdk:
 - oraclejdk8
 script:
 - ./gradlew --info check jacocoTestReport
+dist: trusty

--- a/src/main/java/org/embulk/input/marketo/delegate/CustomObjectInputPlugin.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/CustomObjectInputPlugin.java
@@ -15,6 +15,7 @@ import org.embulk.input.marketo.MarketoUtils;
 import org.embulk.input.marketo.rest.MarketoRestClient;
 import org.embulk.spi.Exec;
 import org.slf4j.Logger;
+
 import java.util.Iterator;
 
 public class CustomObjectInputPlugin extends MarketoBaseInputPluginDelegate<CustomObjectInputPlugin.PluginTask>
@@ -71,5 +72,4 @@ public class CustomObjectInputPlugin extends MarketoBaseInputPluginDelegate<Cust
             return customObjectResponseMapperBuilder.buildServiceResponseMapper(task);
         }
     }
-
 }

--- a/src/main/java/org/embulk/input/marketo/delegate/CustomObjectResponseMapperBuilder.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/CustomObjectResponseMapperBuilder.java
@@ -12,6 +12,7 @@ import org.embulk.input.marketo.MarketoUtils;
 import org.embulk.input.marketo.model.MarketoField;
 import org.embulk.spi.Exec;
 import org.slf4j.Logger;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;

--- a/src/main/java/org/embulk/input/marketo/delegate/ProgramInputPlugin.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/ProgramInputPlugin.java
@@ -179,7 +179,6 @@ public class ProgramInputPlugin extends MarketoBaseInputPluginDelegate<ProgramIn
         ConfigDiff configDiff = super.buildConfigDiff(task, schema, taskCount, taskReports);
         // set next next earliestUpdatedAt, latestUpdatedAt
         if (task.getQueryBy().isPresent() && task.getQueryBy().get() == QueryBy.DATE_RANGE && task.getIncremental()) {
-
             DateTime earliest = new DateTime(task.getEarliestUpdatedAt().get());
             DateTime latest = new DateTime(task.getLatestUpdatedAt().get());
 

--- a/src/test/java/org/embulk/input/marketo/delegate/CustomObjectInputPluginTest.java
+++ b/src/test/java/org/embulk/input/marketo/delegate/CustomObjectInputPluginTest.java
@@ -21,6 +21,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+
 import java.io.IOException;
 import java.util.List;
 

--- a/src/test/java/org/embulk/input/marketo/delegate/ProgramInputPluginTest.java
+++ b/src/test/java/org/embulk/input/marketo/delegate/ProgramInputPluginTest.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
-
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.embulk.EmbulkTestRuntime;
 import org.embulk.base.restclient.ServiceResponseMapper;
 import org.embulk.base.restclient.record.RecordImporter;
@@ -45,11 +45,9 @@ import java.util.List;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 public class ProgramInputPluginTest
 {
-    private static final DateTimeFormatter DATE_FORMATER = DateTimeFormat.forPattern(MarketoUtils.MARKETO_DATE_SIMPLE_DATE_FORMAT);
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormat.forPattern(MarketoUtils.MARKETO_DATE_SIMPLE_DATE_FORMAT);
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -153,7 +151,7 @@ public class ProgramInputPluginTest
         DateTime earliestUpdatedAt = DateTime.now().plusDays(1);
         DateTime latestUpdatedAt = DateTime.now().minusDays(2);
         thrown.expect(ConfigException.class);
-        thrown.expectMessage(String.format("`earliest_updated_at` (%s) cannot precede the current date ", earliestUpdatedAt.toString(DATE_FORMATER)));
+        thrown.expectMessage(String.format("`earliest_updated_at` (%s) cannot precede the current date ", earliestUpdatedAt.toString(DATE_FORMATTER)));
         ConfigSource config = baseConfig
                         .set("query_by", Optional.of(QueryBy.DATE_RANGE))
                         .set("earliest_updated_at", Optional.of(earliestUpdatedAt))
@@ -168,8 +166,8 @@ public class ProgramInputPluginTest
         DateTime latestUpdatedAt = DateTime.now().minusDays(20);
         thrown.expect(ConfigException.class);
         thrown.expectMessage(String.format("Invalid date range. `earliest_updated_at` (%s) cannot precede the `latest_updated_at` (%s).",
-                        earliestUpdatedAt.toString(DATE_FORMATER),
-                        latestUpdatedAt.toString(DATE_FORMATER)));
+                        earliestUpdatedAt.toString(DATE_FORMATTER),
+                        latestUpdatedAt.toString(DATE_FORMATTER)));
 
         ConfigSource config = baseConfig
                         .set("query_by", Optional.of(QueryBy.DATE_RANGE))
@@ -218,7 +216,7 @@ public class ProgramInputPluginTest
         String earliestUpdatedAtStr = taskReport.get(String.class, "earliest_updated_at");
         long duration = taskReport.get(Long.class, "report_duration");
         assertEquals(duration, reportDuration);
-        assertEquals(earliestUpdatedAtStr, earliestUpdatedAt.toString(DATE_FORMATER));
+        assertEquals(earliestUpdatedAtStr, earliestUpdatedAt.toString(DATE_FORMATTER));
     }
 
     @Test
@@ -239,7 +237,7 @@ public class ProgramInputPluginTest
         String nextErliestUpdatedAt = diff.get(String.class, "earliest_updated_at");
 
         assertEquals(reportDuration, new Duration(earliestUpdatedAt, latestUpdatedAt).getMillis());
-        assertEquals(nextErliestUpdatedAt, latestUpdatedAt.plusSeconds(1).toString(DATE_FORMATER));
+        assertEquals(nextErliestUpdatedAt, latestUpdatedAt.plusSeconds(1).toString(DATE_FORMATTER));
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Current code doesn't count on the HttpResponseException. When the server responses with code do not equal 200 it simply throws the exception up to Embulk.
This fix will wrap all API call and when the HttpResponseException occurred will re-throw with ConfigException or DataException instead.

### Are all connections created by the plugin secure?

- [x] Does it opt secure communication standard? Such as HTTPS, SSH, SFTP, SMTP STARTTLS. If not check with CISO to decide we can deploy the plugin.
- [x] Does support both authentication and encryption appropriately? Such as: "just encrypting without authentication" that is insecure.

### Does the plugin connect only to its expected external site which the customer explicitly set in their config file?

- [x] Does NOT connect unexpected external site and our internal endpoints? Such as: “v3/job/:id/set_started” callback endpoint.

### Does NOT the plugin persist any customers' private information? Identify the private information beforehand.

- [x] Does NOT include them in (temporary) files?
- [x] Does NOT include them in log messages and exception messages?

### What kind of environments does the plugin interact with?

- [x] Does NOT execute any shell command?
- [x] Does NOT read any files on the running instance? Such as: "/etc/passwords". It’s ok to read temporary files that the plugin wrote.
- [x] Does use to create temporary files by spi.TempFileSpace utility to avoid the conflict of the file names.
- [x] Does NOT get environment variables or JVM system properties at runtime? Such as AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY in environment variables

### Does NOT the plugin use insecure libraries?

- [x] Line up all depending library so that we can identify the impact of security incident of those library if any.
- [x] Check libraries usage of the plugin; all security check list must apply to the library usages. Such as "Are all connections created by the library secure?"

### Does NOT the plugin source code repository contain kinds of credentials

- [x] API keys
- [x] Passwords

### Make sure to free up all resources allocated during Embulk transaction “committing” or “rolling back”or before.

- [x] Network (connections, pooled connections)
- [x] Memory (cache in static variables)
- [x] File (temporary files)
- [x] CPU (threads, processes)