### PR TITLE
Support import subset of Leads by provided Lists Ids or Program Ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.19 - 2020-07-06
+* [enhancement] Support import Lead/Member by input static List,Program IDs [100](https://github.com/treasure-data/embulk-input-marketo/pull/100)
+* [enhancement] Support string comma-separated filterValues for Custom Objects [100](https://github.com/treasure-data/embulk-input-marketo/pull/100)
+
 ## 0.6.18 - 2020-01-06
 * [enhancement] Support Marketo Partner API Key [#98](https://github.com/treasure-data/embulk-input-marketo/pull/98)
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ Configuration:
 
 | name                | required | default value | description                                                                                                     |
 |---------------------|----------|---------------|-----------------------------------------------------------------------------------------------------------------|
-| **included_fields** | false    | null         | List of lead fields to included in export request sent to Marketo, can be used to reduce request, response size |
+| **included_fields** | false    | null          | List of lead fields to included in export request sent to Marketo, can be used to reduce request, response size |
+| **list_ids**        | false    | null          | Import Leads by specified Lists_ID. If not specified will import all Leads by all List IDs                      |
 
 Schema type: Dynamic via describe leads. Schema will have 1 addition column name listId that contain the id of the list the lead belong to
 
@@ -136,9 +137,10 @@ Extract all Lead data including lead's program id
 
 Configuration:
 
-| name                | required | default value | description                                                                                                     |
-|---------------------|----------|---------------|-----------------------------------------------------------------------------------------------------------------|
-| **included_fields** | false    | null         | List of lead fields to included in export request sent to Marketo, can be used to reduce request, response size |
+| name                | required | default value | description                                                                                                           |
+|---------------------|----------|---------------|-----------------------------------------------------------------------------------------------------------------------|
+| **included_fields** | false    | null          | List of lead fields to included in export request sent to Marketo, can be used to reduce request, response size       |
+| **program_ids**     | false    | null          | Import Members by specified Program_ID (comma-separated). If not specified will import all Members by all Program IDs |
 
 Schema type: Dynamic via describe leads. Schema will have 1 addition column name listId that contain the id of the list the lead belong to
 
@@ -164,13 +166,29 @@ Configuration:
 | **tag_type**                | false    |   null        | Required if query by `tag_type` is selected. Type of program tag                                                                                             |
 | **tag_value**               | false    |   null        | Required if query by `tag_type` is selected. Value of the tag                                                                                                |
 | **report_duration**         | false    |   null        | Amount of milliseconds to fetch from `earliest_updated_at`. If `incremental = true` this value will automatically calculated for the first run by `latest_updated_at` - `earliest_updated_at` |
-| **incremental**             | false    | true          | If incremental is set to true, next run will have `earliest_updated_at` set to the previous `latest_updated_at` + `report_duration`. Incremental import only support by query `date_range`     |
+| **incremental**             | false    |   true        | If incremental is set to true, next run will have `earliest_updated_at` set to the previous `latest_updated_at` + `report_duration`. Incremental import only support by query `date_range`     |
 
 Schema type: Static schema
 
 Incremental support: yes (Query by `date_range` only)
 
 Range ingestion: yes
+
+`target: all_lead_with_program_id`
+
+Configuration:
+
+| name                                  | required | default value | description                                                                                                           |
+|---------------------------------------|----------|---------------|-----------------------------------------------------------------------------------------------------------------------|
+| **custom_object_api_name**            | true     | null          | The API name of the custom object                                                                                     |
+| **custom_object_fields**              | false    | null          | Comma separated API name of fields of the custom object (Optional)                                                    |
+| **custom_object_filter_type**         | true     | null          | Field to search on Valid values are: dedupeFields, idFields, and any field defined in searchableFields attribute of Describe endpoint. Default is dedupeFields |
+| **custom_object_filter_values**       | false    | null          | Comma-separated list of field values to match.                                                                        |
+| **custom_object_filter_from_value**   | false    | null          | Filter Marketo Custom Object has value greater than this value                                                        |
+| **custom_object_filter_to_value**     | false    | null          | Filter Marketo Custom Object has value smaller than this value. If not set, only records that have value greater than "From Value" will be returned. Job will stop if no record found in 300 consecutive value. |
+
+Schema type: dynamic schema
+Incremental support: no 
 
 ## Example
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,9 +16,9 @@ repositories {
 configurations {
     provided
 }
-version = "0.6.18"
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+version = "0.6.19"
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 dependencies {
     compile  "org.embulk:embulk-core:0.8.+"

--- a/src/main/java/org/embulk/input/marketo/MarketoService.java
+++ b/src/main/java/org/embulk/input/marketo/MarketoService.java
@@ -33,6 +33,8 @@ public interface MarketoService
 
     Iterable<ObjectNode> getProgramsByDateRange(Date earliestUpdatedAt, Date latestUpdatedAt, String filterType, List<String> filterValues);
 
+    Iterable<ObjectNode> getCustomObject(String customObjectApiName, String filterType, Set<String> filterValues, String returnFields);
+
     Iterable<ObjectNode> getCustomObject(String customObjectAPIName, String customObjectFilterType, String customObjectFields, Integer fromValue, Integer toValue);
 
     List<MarketoField> describeCustomObject(String customObjectAPIName);

--- a/src/main/java/org/embulk/input/marketo/MarketoService.java
+++ b/src/main/java/org/embulk/input/marketo/MarketoService.java
@@ -6,6 +6,7 @@ import org.embulk.input.marketo.model.MarketoField;
 import java.io.File;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Created by tai.khuu on 9/6/17.
@@ -18,13 +19,15 @@ public interface MarketoService
 
     File extractAllActivity(List<Integer> activityTypeIds, Date startTime, Date endTime, int pollingTimeIntervalSecond, int bulkJobTimeoutSecond);
 
-    Iterable<ObjectNode> getAllListLead(List<String> extractFields);
+    Iterable<ObjectNode> getAllListLead(List<String> extractFields, Iterable<ObjectNode> inputListIds);
 
-    Iterable<ObjectNode> getAllProgramLead(List<String> extractFields);
+    Iterable<ObjectNode> getAllProgramLead(List<String> extractFields, Iterable<ObjectNode> requestProgs);
 
     Iterable<ObjectNode> getCampaign();
 
     Iterable<ObjectNode> getPrograms();
+
+    Iterable<ObjectNode> getProgramsByIds(Set<String> ids);
 
     Iterable<ObjectNode> getProgramsByTag(String tagType, String tagValue);
 
@@ -35,4 +38,8 @@ public interface MarketoService
     List<MarketoField> describeCustomObject(String customObjectAPIName);
 
     Iterable<ObjectNode> getActivityTypes();
+
+    Iterable<ObjectNode> getListsByIds(Set<String> ids);
+
+    Iterable<ObjectNode> getLists();
 }

--- a/src/main/java/org/embulk/input/marketo/delegate/CustomObjectInputPlugin.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/CustomObjectInputPlugin.java
@@ -1,7 +1,9 @@
 package org.embulk.input.marketo.delegate;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Optional;
 import com.google.common.collect.FluentIterable;
+import com.google.common.collect.Iterables;
 import org.apache.commons.lang3.StringUtils;
 import org.embulk.base.restclient.ServiceResponseMapper;
 import org.embulk.base.restclient.record.ServiceRecord;
@@ -17,6 +19,9 @@ import org.embulk.spi.Exec;
 import org.slf4j.Logger;
 
 import java.util.Iterator;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class CustomObjectInputPlugin extends MarketoBaseInputPluginDelegate<CustomObjectInputPlugin.PluginTask>
 {
@@ -35,6 +40,10 @@ public class CustomObjectInputPlugin extends MarketoBaseInputPluginDelegate<Cust
         @Config("custom_object_filter_to_value")
         @ConfigDefault("null")
         Optional<Integer> getToValue();
+
+        @Config("custom_object_filter_values")
+        @ConfigDefault("\"\"")
+        String getCustomObjectFilterValues();
     }
 
     public CustomObjectInputPlugin()
@@ -51,16 +60,56 @@ public class CustomObjectInputPlugin extends MarketoBaseInputPluginDelegate<Cust
         if (StringUtils.isBlank(task.getCustomObjectAPIName())) {
             throw new ConfigException("`custom_object_api_name` cannot be empty");
         }
-        if (task.getToValue().isPresent() && task.getToValue().get() < task.getFromValue()) {
-            throw new ConfigException(String.format("`to_value` (%s) cannot be less than  the `from_value` (%s)", task.getToValue().get(), task.getFromValue()));
+        if (StringUtils.isBlank(task.getCustomObjectFilterValues())) {
+            if (task.getToValue().isPresent() && !isValidFilterRange(task)) {
+                throw new ConfigException(String.format("`to_value` (%s) cannot be less than the `from_value` (%s)", task.getToValue().get(), task.getFromValue()));
+            }
+        }
+        else if (refineFilterValues(task.getCustomObjectFilterValues()).isEmpty()) {
+            throw new ConfigException("`custom_object_filter_values` cannot contain empty values only");
         }
     }
+
+    private Set<String> refineFilterValues(String filterValues)
+    {
+        return Stream.of(StringUtils.split(filterValues, ",")).filter(StringUtils::isNotBlank).collect(Collectors.toSet());
+    }
+
+    private boolean isValidFilterRange(PluginTask task)
+    {
+        return task.getToValue().get() > task.getFromValue();
+    }
+
     @Override
     protected Iterator<ServiceRecord> getServiceRecords(MarketoService marketoService, PluginTask task)
     {
-        return FluentIterable
-                .from(marketoService.getCustomObject(task.getCustomObjectAPIName(), task.getCustomObjectFilterType(), task.getCustomObjectFields().orNull(), task.getFromValue(), task.getToValue().orNull()))
-                .transform(MarketoUtils.TRANSFORM_OBJECT_TO_JACKSON_SERVICE_RECORD_FUNCTION).iterator();
+        Iterable<ObjectNode> responseObj;
+        if (StringUtils.isNotBlank(task.getCustomObjectFilterValues())) {
+            Set<String> refinedValues = refineFilterValues(task.getCustomObjectFilterValues());
+            responseObj = marketoService.getCustomObject(task.getCustomObjectAPIName(), task.getCustomObjectFilterType(), refinedValues, task.getCustomObjectFields().orNull());
+        }
+        else {
+            // When `to_value` is not set, will try to import all consecutive custom objects started from `from_value`
+            responseObj = marketoService.getCustomObject(task.getCustomObjectAPIName(), task.getCustomObjectFilterType(), task.getCustomObjectFields().orNull(), task.getFromValue(), task.getToValue().orNull());
+        }
+
+        return FluentIterable.from(filterInvalidRecords(responseObj)).transform(MarketoUtils.TRANSFORM_OBJECT_TO_JACKSON_SERVICE_RECORD_FUNCTION).iterator();
+    }
+
+    /**
+     * Marketo include error in invalid records. This method will filter those records and print it to output log
+     * @param resultIt
+     * @return
+     */
+    private Iterable<ObjectNode> filterInvalidRecords(Iterable<ObjectNode> resultIt)
+    {
+        return Iterables.filter(resultIt, (obj) -> {
+            if (obj.has("reasons")) {
+                logger.warn(obj.get("reasons").toString());
+                return false;
+            }
+            return true;
+        });
     }
 
     @Override

--- a/src/main/java/org/embulk/input/marketo/delegate/LeadWithListInputPlugin.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/LeadWithListInputPlugin.java
@@ -1,18 +1,26 @@
 package org.embulk.input.marketo.delegate;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.base.Optional;
 import com.google.common.collect.FluentIterable;
-
+import org.apache.commons.lang3.StringUtils;
 import org.embulk.base.restclient.ServiceResponseMapper;
 import org.embulk.base.restclient.record.ServiceRecord;
 import org.embulk.base.restclient.record.ValueLocator;
+import org.embulk.config.Config;
+import org.embulk.config.ConfigDefault;
 import org.embulk.input.marketo.MarketoService;
 import org.embulk.input.marketo.MarketoServiceImpl;
 import org.embulk.input.marketo.MarketoUtils;
 import org.embulk.input.marketo.model.MarketoField;
 import org.embulk.input.marketo.rest.MarketoRestClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
 
 /**
  * Created by tai.khuu on 9/18/17.
@@ -21,6 +29,13 @@ public class LeadWithListInputPlugin extends MarketoBaseInputPluginDelegate<Lead
 {
     public interface PluginTask extends MarketoBaseInputPluginDelegate.PluginTask, LeadServiceResponseMapperBuilder.PluginTask
     {
+        @Config("list_ids")
+        @ConfigDefault("null")
+        Optional<String> getListIds();
+
+        @Config("skip_invalid_list_id")
+        @ConfigDefault("false")
+        boolean getSkipInvalidList();
     }
 
     public LeadWithListInputPlugin()
@@ -31,9 +46,25 @@ public class LeadWithListInputPlugin extends MarketoBaseInputPluginDelegate<Lead
     protected Iterator<ServiceRecord> getServiceRecords(MarketoService marketoService, PluginTask task)
     {
         List<String> extractedFields = task.getExtractedFields();
+
+        Iterable<ObjectNode> requestLists;
+        if (isUserInputLists(task)) {
+            final String[] idsStr = StringUtils.split(task.getListIds().get(), ID_LIST_SEPARATOR_CHAR);
+            Function<Set<String>, Iterable<ObjectNode>> getListIds = (ids) -> marketoService.getListsByIds(ids);
+            requestLists = super.getObjectsByIds(idsStr, task.getSkipInvalidList(), getListIds);
+        }
+        else {
+            requestLists = marketoService.getLists();
+        }
+
         // Remove LIST_ID_COLUMN_NAME when sent fields to Marketo since LIST_ID_COLUMN_NAME are added by plugin code
         extractedFields.remove(MarketoUtils.LIST_ID_COLUMN_NAME);
-        return FluentIterable.from(marketoService.getAllListLead(extractedFields)).transform(MarketoUtils.TRANSFORM_OBJECT_TO_JACKSON_SERVICE_RECORD_FUNCTION).iterator();
+        return FluentIterable.from(marketoService.getAllListLead(extractedFields, requestLists)).transform(MarketoUtils.TRANSFORM_OBJECT_TO_JACKSON_SERVICE_RECORD_FUNCTION).iterator();
+    }
+
+    private boolean isUserInputLists(PluginTask task)
+    {
+        return task.getListIds().isPresent() && StringUtils.isNotBlank(task.getListIds().get());
     }
 
     @Override

--- a/src/main/java/org/embulk/input/marketo/delegate/LeadWithProgramInputPlugin.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/LeadWithProgramInputPlugin.java
@@ -30,10 +30,6 @@ public class LeadWithProgramInputPlugin extends MarketoBaseInputPluginDelegate<L
         @Config("program_ids")
         @ConfigDefault("null")
         Optional<String> getProgramIds();
-
-        @Config("skip_invalid_program_id")
-        @ConfigDefault("false")
-        boolean getSkipInvalidProgram();
     }
 
     @Override
@@ -41,19 +37,19 @@ public class LeadWithProgramInputPlugin extends MarketoBaseInputPluginDelegate<L
     {
         List<String> fieldNames = task.getExtractedFields();
 
-        Iterable<ObjectNode> requestProgs;
+        Iterable<ObjectNode> programsToRequest;
         if (isUserInputProgs(task)) {
             final String[] idsStr = StringUtils.split(task.getProgramIds().get(), ID_LIST_SEPARATOR_CHAR);
             Function<Set<String>, Iterable<ObjectNode>> getListIds = (ids) -> marketoService.getProgramsByIds(ids);
-            requestProgs = super.getObjectsByIds(idsStr, task.getSkipInvalidProgram(), getListIds);
+            programsToRequest = super.getObjectsByIds(idsStr, getListIds);
         }
         else {
-            requestProgs = marketoService.getPrograms();
+            programsToRequest = marketoService.getPrograms();
         }
 
         // Remove PROGRAM_ID_COLUMN_NAME when sent fields to Marketo since PROGRAM_ID_COLUMN_NAME are added by plugin code
         fieldNames.remove(MarketoUtils.PROGRAM_ID_COLUMN_NAME);
-        return FluentIterable.from(marketoService.getAllProgramLead(fieldNames, requestProgs)).transform(MarketoUtils.TRANSFORM_OBJECT_TO_JACKSON_SERVICE_RECORD_FUNCTION).iterator();
+        return FluentIterable.from(marketoService.getAllProgramLead(fieldNames, programsToRequest)).transform(MarketoUtils.TRANSFORM_OBJECT_TO_JACKSON_SERVICE_RECORD_FUNCTION).iterator();
     }
 
     private boolean isUserInputProgs(LeadWithProgramInputPlugin.PluginTask task)

--- a/src/main/java/org/embulk/input/marketo/delegate/MarketoBaseInputPluginDelegate.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/MarketoBaseInputPluginDelegate.java
@@ -1,7 +1,9 @@
 package org.embulk.input.marketo.delegate;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
-
+import com.google.common.collect.Lists;
+import org.apache.commons.lang3.StringUtils;
 import org.embulk.base.restclient.DefaultServiceDataSplitter;
 import org.embulk.base.restclient.RestClientInputPluginDelegate;
 import org.embulk.base.restclient.RestClientInputTaskBase;
@@ -11,6 +13,7 @@ import org.embulk.base.restclient.record.ServiceRecord;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigDiff;
+import org.embulk.config.ConfigException;
 import org.embulk.config.TaskReport;
 import org.embulk.input.marketo.MarketoService;
 import org.embulk.input.marketo.MarketoServiceImpl;
@@ -19,16 +22,26 @@ import org.embulk.spi.Exec;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.Schema;
 import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Created by tai.khuu on 9/18/17.
  */
 public abstract class MarketoBaseInputPluginDelegate<T extends MarketoBaseInputPluginDelegate.PluginTask> implements RestClientInputPluginDelegate<T>
 {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     public static final int PREVIEW_RECORD_LIMIT = 15;
+    public static final String ID_LIST_SEPARATOR_CHAR = ",";
+
     public interface PluginTask
             extends RestClientInputTaskBase, MarketoRestClient.PluginTask
     {
@@ -88,5 +101,66 @@ public abstract class MarketoBaseInputPluginDelegate<T extends MarketoBaseInputP
     public ServiceDataSplitter<T> buildServiceDataSplitter(T task)
     {
         return new DefaultServiceDataSplitter();
+    }
+
+    protected Iterable<ObjectNode> getObjectsByIds(String[] inputIds, boolean ignoreInvalid, Function<Set<String>, Iterable<ObjectNode>> getByIdFunction)
+    {
+        final Set<String> ids = new HashSet<>();
+        final List<String> invalidIds = new ArrayList<>();
+
+        for (int i = 0; i < inputIds.length; i++) {
+            String currentId = StringUtils.trimToNull(inputIds[i]);
+            // ignore null or empty ids
+            if (currentId == null) {
+                continue;
+            }
+
+            // ignore or throw for NaN ids
+            if (StringUtils.isNumeric(currentId)) {
+                ids.add(currentId);
+            }
+            else {
+                invalidIds.add(inputIds[i]);
+            }
+        }
+
+        if (ids.isEmpty()) {
+            throw new ConfigException("No valid Id specified");
+        }
+
+        if (!invalidIds.isEmpty()) {
+            if (!ignoreInvalid) {
+                throw new ConfigException("Invalid Id(s): " + invalidIds);
+            }
+            logger.warn("Skip invalid Id(s): {}", invalidIds);
+        }
+
+        List<ObjectNode> actualList = Lists.newArrayList(getByIdFunction.apply(ids));
+        if (actualList.isEmpty()) {
+            throw new ConfigException("No valid Id found");
+        }
+
+        if (actualList.size() != ids.size()) {
+            // find the ignored ids
+            checkOrThrow(ids, actualList, ignoreInvalid);
+        }
+
+        return actualList;
+    }
+
+    private void checkOrThrow(Set<String> ids, List<ObjectNode> actualList, boolean ignoreInvalid)
+    {
+        List<String> actualIds = actualList.parallelStream().map(n -> String.valueOf(n.get("id").asInt())).collect(Collectors.toList());
+        List<String> missingIds = new ArrayList<>();
+        for (String id : ids) {
+            if (!actualIds.contains(id)) {
+                missingIds.add(id);
+            }
+        }
+
+        if (!ignoreInvalid) {
+            throw new ConfigException("Invalid non-existent Id(s): " + missingIds);
+        }
+        logger.warn("Skip non-existent Id(s): {}", missingIds);
     }
 }

--- a/src/main/java/org/embulk/input/marketo/delegate/MarketoBaseInputPluginDelegate.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/MarketoBaseInputPluginDelegate.java
@@ -103,7 +103,7 @@ public abstract class MarketoBaseInputPluginDelegate<T extends MarketoBaseInputP
         return new DefaultServiceDataSplitter();
     }
 
-    protected Iterable<ObjectNode> getObjectsByIds(String[] inputIds, boolean ignoreInvalid, Function<Set<String>, Iterable<ObjectNode>> getByIdFunction)
+    protected Iterable<ObjectNode> getObjectsByIds(String[] inputIds, Function<Set<String>, Iterable<ObjectNode>> getByIdFunction)
     {
         final Set<String> ids = new HashSet<>();
         final List<String> invalidIds = new ArrayList<>();
@@ -129,10 +129,7 @@ public abstract class MarketoBaseInputPluginDelegate<T extends MarketoBaseInputP
         }
 
         if (!invalidIds.isEmpty()) {
-            if (!ignoreInvalid) {
-                throw new ConfigException("Invalid Id(s): " + invalidIds);
-            }
-            logger.warn("Skip invalid Id(s): {}", invalidIds);
+            logger.warn("Ignore invalid Id(s): {}", invalidIds);
         }
 
         List<ObjectNode> actualList = Lists.newArrayList(getByIdFunction.apply(ids));
@@ -141,14 +138,13 @@ public abstract class MarketoBaseInputPluginDelegate<T extends MarketoBaseInputP
         }
 
         if (actualList.size() != ids.size()) {
-            // find the ignored ids
-            checkOrThrow(ids, actualList, ignoreInvalid);
+            logNoneExistedIds(ids, actualList);
         }
 
         return actualList;
     }
 
-    private void checkOrThrow(Set<String> ids, List<ObjectNode> actualList, boolean ignoreInvalid)
+    private void logNoneExistedIds(Set<String> ids, List<ObjectNode> actualList)
     {
         List<String> actualIds = actualList.parallelStream().map(n -> String.valueOf(n.get("id").asInt())).collect(Collectors.toList());
         List<String> missingIds = new ArrayList<>();
@@ -157,10 +153,6 @@ public abstract class MarketoBaseInputPluginDelegate<T extends MarketoBaseInputP
                 missingIds.add(id);
             }
         }
-
-        if (!ignoreInvalid) {
-            throw new ConfigException("Invalid non-existent Id(s): " + missingIds);
-        }
-        logger.warn("Skip non-existent Id(s): {}", missingIds);
+        logger.warn("Ignore not exists Id(s): {}", missingIds);
     }
 }

--- a/src/main/java/org/embulk/input/marketo/rest/MarketoRestClient.java
+++ b/src/main/java/org/embulk/input/marketo/rest/MarketoRestClient.java
@@ -577,6 +577,18 @@ public class MarketoRestClient extends MarketoBaseRestClient
             }
         });
     }
+
+    public Iterable<ObjectNode> getCustomObject(String customObjectApiName, String filterType, String filterValue, String returnFields)
+    {
+        Multimap<String, String> params = new ImmutableListMultimap
+                .Builder<String, String>()
+                .put("filterType", StringUtils.trimToEmpty(filterType))
+                .put("filterValues", StringUtils.trimToEmpty(filterValue))
+                .put("fields", StringUtils.trimToEmpty(returnFields))
+                .put(BATCH_SIZE, MAX_BATCH_SIZE).build();
+        return getRecordWithTokenPagination(endPoint + MarketoRESTEndpoint.GET_CUSTOM_OBJECT.getEndpoint(new ImmutableMap.Builder().put("api_name", customObjectApiName).build()), params, ObjectNode.class);
+    }
+
     public Iterable<ObjectNode> getCustomObject(String customObjectAPIName, String customObjectFilterType, String customObjectFields, Integer fromValue, Integer toValue)
     {
         return getCustomObjectRecordWithPagination(endPoint + MarketoRESTEndpoint.GET_CUSTOM_OBJECT.getEndpoint(new ImmutableMap.Builder().put("api_name", customObjectAPIName).build()), customObjectFilterType, customObjectFields, fromValue, toValue, ObjectNode.class);

--- a/src/main/java/org/embulk/input/marketo/rest/MarketoRestClient.java
+++ b/src/main/java/org/embulk/input/marketo/rest/MarketoRestClient.java
@@ -37,6 +37,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Created by tai.khuu on 8/22/17.
@@ -357,9 +358,28 @@ public class MarketoRestClient extends MarketoBaseRestClient
         return getRecordWithTokenPagination(endPoint + MarketoRESTEndpoint.GET_LISTS.getEndpoint(), new ImmutableListMultimap.Builder<String, String>().put(BATCH_SIZE, MAX_BATCH_SIZE).build(), ObjectNode.class);
     }
 
+    public RecordPagingIterable<ObjectNode> getListsByIds(Set<String> ids)
+    {
+        Multimap<String, String> params = new ImmutableListMultimap
+                .Builder<String, String>()
+                .put("id", StringUtils.join(ids, ","))
+                .put(BATCH_SIZE, MAX_BATCH_SIZE).build();
+        return getRecordWithTokenPagination(endPoint + MarketoRESTEndpoint.GET_LISTS.getEndpoint(), params, ObjectNode.class);
+    }
+
     public RecordPagingIterable<ObjectNode> getPrograms()
     {
         return getRecordWithOffsetPagination(endPoint + MarketoRESTEndpoint.GET_PROGRAMS.getEndpoint(), new ImmutableListMultimap.Builder<String, String>().put(MAX_RETURN, DEFAULT_MAX_RETURN).build(), ObjectNode.class);
+    }
+
+    public RecordPagingIterable<ObjectNode> getProgramsByIds(Set<String> ids)
+    {
+        Multimap<String, String> params = new ImmutableListMultimap
+                .Builder<String, String>()
+                .put(FILTER_TYPE, "id")
+                .put(FILTER_VALUES, StringUtils.join(ids, ","))
+                .put(BATCH_SIZE, MAX_BATCH_SIZE).build();
+        return getRecordWithOffsetPagination(endPoint + MarketoRESTEndpoint.GET_PROGRAMS.getEndpoint(), params, ObjectNode.class);
     }
 
     public RecordPagingIterable<ObjectNode> getLeadsByProgram(String programId, String fieldNames)

--- a/src/test/java/org/embulk/input/marketo/MarketoServiceImplTest.java
+++ b/src/test/java/org/embulk/input/marketo/MarketoServiceImplTest.java
@@ -16,10 +16,10 @@ import org.mockito.Mockito;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.Iterator;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -79,35 +79,40 @@ public class MarketoServiceImplTest
     public void getAllListLead() throws Exception
     {
         List<String> extractFields = Arrays.asList("field1", "field2");
-        RecordPagingIterable<ObjectNode> listObjectNodes = Mockito.mock(RecordPagingIterable.class);
-        Iterator listIterator = Mockito.mock(Iterator.class);
-        Mockito.when(listIterator.hasNext()).thenReturn(true).thenReturn(true).thenReturn(false);
-        Mockito.when(listIterator.next()).thenReturn(OBJECT_MAPPER.readTree("{\"id\":1}")).thenReturn(OBJECT_MAPPER.readTree("{\"id\":2}"));
-        Mockito.when(listObjectNodes.iterator()).thenReturn(listIterator);
-        List<ObjectNode> leadList1 = new ArrayList<>();
-        leadList1.add((ObjectNode) OBJECT_MAPPER.readTree("{\"id\":\"lead1\"}"));
-        List<ObjectNode> leadList2 = new ArrayList<>();
-        leadList2.add((ObjectNode) OBJECT_MAPPER.readTree("{\"id\":\"lead2\"}"));
-        Mockito.when(mockMarketoRestClient.getLists()).thenReturn(listObjectNodes);
+        List<ObjectNode> allLists = mockParent();
+
+        List<ObjectNode> lead1 = new ArrayList<>();
+        lead1.add((ObjectNode) OBJECT_MAPPER.readTree("{\"id\":\"lead1\"}"));
+        List<ObjectNode> lead2 = new ArrayList<>();
+        lead2.add((ObjectNode) OBJECT_MAPPER.readTree("{\"id\":\"lead2\"}"));
+
         RecordPagingIterable leadIterable1 = Mockito.mock(RecordPagingIterable.class);
         RecordPagingIterable leadsIterable2 = Mockito.mock(RecordPagingIterable.class);
-        Mockito.when(leadIterable1.iterator()).thenReturn(leadList1.iterator());
-        Mockito.when(leadsIterable2.iterator()).thenReturn(leadList2.iterator());
+        Mockito.when(leadIterable1.iterator()).thenReturn(lead1.iterator());
+        Mockito.when(leadsIterable2.iterator()).thenReturn(lead2.iterator());
+
         Mockito.when(mockMarketoRestClient.getLeadsByList(Mockito.eq("1"), Mockito.eq("field1,field2"))).thenReturn(leadIterable1);
         Mockito.when(mockMarketoRestClient.getLeadsByList(Mockito.eq("2"), Mockito.eq("field1,field2"))).thenReturn(leadsIterable2);
-        Iterable<ObjectNode> allListLead = marketoService.getAllListLead(extractFields);
-        Assert.assertEquals(leadList1.get(0), allListLead.iterator().next());
-        Assert.assertEquals(leadList2.get(0), allListLead.iterator().next());
+
+        Iterable<ObjectNode> allListLead = marketoService.getAllListLead(extractFields, allLists);
+        Assert.assertEquals(lead1.get(0), allListLead.iterator().next());
+        Assert.assertEquals(lead2.get(0), allListLead.iterator().next());
+    }
+
+    private List<ObjectNode> mockParent() throws IOException
+    {
+        List<ObjectNode> allLists = new ArrayList<>();
+        allLists.add((ObjectNode) OBJECT_MAPPER.readTree("{\"id\": 1}"));
+        allLists.add((ObjectNode) OBJECT_MAPPER.readTree("{\"id\": 2}"));
+        return allLists;
     }
 
     @Test
     public void getAllProgramLead() throws Exception
     {
         RecordPagingIterable<ObjectNode> listObjectNodes = Mockito.mock(RecordPagingIterable.class);
-        Iterator listIterator = Mockito.mock(Iterator.class);
-        Mockito.when(listIterator.hasNext()).thenReturn(true).thenReturn(true).thenReturn(false);
-        Mockito.when(listIterator.next()).thenReturn(OBJECT_MAPPER.readTree("{\"id\":1}")).thenReturn(OBJECT_MAPPER.readTree("{\"id\":2}"));
-        Mockito.when(listObjectNodes.iterator()).thenReturn(listIterator);
+        Iterable listIterator = mockParent();
+
         List<ObjectNode> leadList1 = new ArrayList<>();
         leadList1.add((ObjectNode) OBJECT_MAPPER.readTree("{\"id\":\"lead1\"}"));
         List<ObjectNode> leadList2 = new ArrayList<>();
@@ -117,9 +122,11 @@ public class MarketoServiceImplTest
         RecordPagingIterable leadsIterable2 = Mockito.mock(RecordPagingIterable.class);
         Mockito.when(leadIterable1.iterator()).thenReturn(leadList1.iterator());
         Mockito.when(leadsIterable2.iterator()).thenReturn(leadList2.iterator());
+
         Mockito.when(mockMarketoRestClient.getLeadsByProgram(Mockito.eq("1"), Mockito.eq("field1,field2"))).thenReturn(leadIterable1);
         Mockito.when(mockMarketoRestClient.getLeadsByProgram(Mockito.eq("2"), Mockito.eq("field1,field2"))).thenReturn(leadsIterable2);
-        Iterable<ObjectNode> allListLead = marketoService.getAllProgramLead(Arrays.asList("field1", "field2"));
+
+        Iterable<ObjectNode> allListLead = marketoService.getAllProgramLead(Arrays.asList("field1", "field2"), listIterator);
         Assert.assertEquals(leadList1.get(0), allListLead.iterator().next());
         Assert.assertEquals(leadList2.get(0), allListLead.iterator().next());
     }

--- a/src/test/java/org/embulk/input/marketo/delegate/CustomObjectInputPluginTest.java
+++ b/src/test/java/org/embulk/input/marketo/delegate/CustomObjectInputPluginTest.java
@@ -3,7 +3,6 @@ package org.embulk.input.marketo.delegate;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.base.Optional;
 import org.embulk.EmbulkTestRuntime;
 import org.embulk.base.restclient.ServiceResponseMapper;
 import org.embulk.base.restclient.record.RecordImporter;
@@ -16,6 +15,7 @@ import org.embulk.input.marketo.rest.MarketoRestClient;
 import org.embulk.input.marketo.rest.RecordPagingIterable;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.Schema;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -50,33 +50,118 @@ public class CustomObjectInputPluginTest
         Mockito.doReturn(mockMarketoRestClient).when(customObjectInputPlugin).createMarketoRestClient(Mockito.any(CustomObjectInputPlugin.PluginTask.class));
     }
 
-    @Test(expected = ConfigException.class)
-    public void validateCustomObjectFilterTypeError()
+    @Test
+    public void testValidPluginTask()
     {
-        CustomObjectInputPlugin.PluginTask pluginTask = Mockito.mock(CustomObjectInputPlugin.PluginTask.class);
-        Mockito.when(pluginTask.getCustomObjectFilterType()).thenReturn("");
-        customObjectInputPlugin.validateInputTask(pluginTask);
-    }
-
-    @Test(expected = ConfigException.class)
-    public void validateCustomObjectAPINameError()
-    {
-        CustomObjectInputPlugin.PluginTask pluginTask = Mockito.mock(CustomObjectInputPlugin.PluginTask.class);
-        Mockito.when(pluginTask.getCustomObjectAPIName()).thenReturn("");
-        customObjectInputPlugin.validateInputTask(pluginTask);
-    }
-
-    @Test(expected = ConfigException.class)
-    public void validateFromValueGreaterThanToValueError()
-    {
-        CustomObjectInputPlugin.PluginTask pluginTask = Mockito.mock(CustomObjectInputPlugin.PluginTask.class);
-        Mockito.when(pluginTask.getFromValue()).thenReturn(100);
-        Mockito.when(pluginTask.getToValue()).thenReturn(Optional.of(90));
+        CustomObjectInputPlugin.PluginTask pluginTask = configSource.loadConfig(CustomObjectInputPlugin.PluginTask.class);
+        // should not cause exception
         customObjectInputPlugin.validateInputTask(pluginTask);
     }
 
     @Test
-    public void testRun() throws IOException
+    public void testCustomObjectFilterTypeError()
+    {
+        CustomObjectInputPlugin.PluginTask pluginTask = configSource
+                .set("custom_object_filter_type", "")
+                .loadConfig(CustomObjectInputPlugin.PluginTask.class);
+        Assert.assertThrows(ConfigException.class, () -> customObjectInputPlugin.validateInputTask(pluginTask));
+    }
+
+    @Test
+    public void testCustomObjectAPINameError()
+    {
+        CustomObjectInputPlugin.PluginTask pluginTask = configSource
+                .set("custom_object_api_name", "")
+                .loadConfig(CustomObjectInputPlugin.PluginTask.class);
+        Assert.assertThrows(ConfigException.class, () -> customObjectInputPlugin.validateInputTask(pluginTask));
+    }
+
+    @Test
+    public void testFromValueGreaterThanToValueError()
+    {
+        CustomObjectInputPlugin.PluginTask pluginTask = configSource
+                .set("custom_object_filter_from_value", "10")
+                .set("custom_object_filter_to_value", "5").loadConfig(CustomObjectInputPlugin.PluginTask.class);
+        Assert.assertThrows(ConfigException.class, () -> customObjectInputPlugin.validateInputTask(pluginTask));
+    }
+
+    @Test
+    public void testEmptyStringFilterValues()
+    {
+        CustomObjectInputPlugin.PluginTask pluginTask = configSource
+                .set("custom_object_filter_values", "").loadConfig(CustomObjectInputPlugin.PluginTask.class);
+
+        Assert.assertThrows(ConfigException.class, () -> customObjectInputPlugin.validateInputTask(pluginTask));
+    }
+
+    @Test
+    public void testAllEmptyStringFilterValues()
+    {
+        CustomObjectInputPlugin.PluginTask pluginTask = configSource
+                .set("custom_object_filter_values", ",, , ").loadConfig(CustomObjectInputPlugin.PluginTask.class);
+
+        Assert.assertThrows(ConfigException.class, () -> customObjectInputPlugin.validateInputTask(pluginTask));
+    }
+
+    @Test
+    public void testRunStringFilterValues() throws IOException
+    {
+        RecordPagingIterable<ObjectNode> mockRecordPagingIterable = mockAndGetResponse();
+        Mockito.when(mockMarketoRestClient.getCustomObject(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString())).thenReturn(mockRecordPagingIterable);
+
+        CustomObjectInputPlugin.PluginTask task = configSource.set("custom_object_filter_values", "value1,value2,value3,value4").loadConfig(CustomObjectInputPlugin.PluginTask.class);
+        ServiceResponseMapper<? extends ValueLocator> mapper = customObjectInputPlugin.buildServiceResponseMapper(task);
+        RecordImporter recordImporter = mapper.createRecordImporter();
+        PageBuilder mockPageBuilder = Mockito.mock(PageBuilder.class);
+        customObjectInputPlugin.ingestServiceData(task, recordImporter, 1, mockPageBuilder);
+        Mockito.verify(mockMarketoRestClient, Mockito.times(1)).getCustomObject(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+
+        verifyAfterRun(mapper, mockPageBuilder);
+    }
+
+    @Test
+    public void testRunWithFilterRange() throws IOException
+    {
+        RecordPagingIterable<ObjectNode> mockRecordPagingIterable = mockAndGetResponse();
+        Mockito.when(mockMarketoRestClient.getCustomObject(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString())).thenReturn(mockRecordPagingIterable);
+
+        CustomObjectInputPlugin.PluginTask task = configSource.loadConfig(CustomObjectInputPlugin.PluginTask.class);
+        ServiceResponseMapper<? extends ValueLocator> mapper = customObjectInputPlugin.buildServiceResponseMapper(task);
+        RecordImporter recordImporter = mapper.createRecordImporter();
+        PageBuilder mockPageBuilder = Mockito.mock(PageBuilder.class);
+        customObjectInputPlugin.ingestServiceData(task, recordImporter, 1, mockPageBuilder);
+        Mockito.verify(mockMarketoRestClient, Mockito.times(1)).getCustomObject(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+
+        verifyAfterRun(mapper, mockPageBuilder);
+    }
+
+    @Test
+    public void testRunFromOnlyFilter() throws IOException
+    {
+        RecordPagingIterable<ObjectNode> mockRecordPagingIterable = mockAndGetResponse();
+        Mockito.when(mockMarketoRestClient.getCustomObject(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyInt(), Mockito.isNull())).thenReturn(mockRecordPagingIterable);
+
+        CustomObjectInputPlugin.PluginTask task = configSource.remove("custom_object_filter_to_value").loadConfig(CustomObjectInputPlugin.PluginTask.class);
+        ServiceResponseMapper<? extends ValueLocator> mapper = customObjectInputPlugin.buildServiceResponseMapper(task);
+        RecordImporter recordImporter = mapper.createRecordImporter();
+        PageBuilder mockPageBuilder = Mockito.mock(PageBuilder.class);
+        customObjectInputPlugin.ingestServiceData(task, recordImporter, 1, mockPageBuilder);
+        Mockito.verify(mockMarketoRestClient, Mockito.times(1)).getCustomObject(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyInt(), Mockito.isNull());
+
+        verifyAfterRun(mapper, mockPageBuilder);
+    }
+
+    private void verifyAfterRun(ServiceResponseMapper<? extends ValueLocator> mapper, PageBuilder mockPageBuilder)
+    {
+        Mockito.verify(mockMarketoRestClient, Mockito.times(1)).describeCustomObject(Mockito.anyString());
+        Schema schema = mapper.getEmbulkSchema();
+        ArgumentCaptor<Long> longArgumentCaptor = ArgumentCaptor.forClass(Long.class);
+        Mockito.verify(mockPageBuilder, Mockito.times(3)).setLong(Mockito.eq(schema.lookupColumn("mk_id")), longArgumentCaptor.capture());
+        List<Long> allValues = longArgumentCaptor.getAllValues();
+        assertArrayEquals(new Long[]{1L, 2L, 3L}, allValues.toArray());
+    }
+
+    private RecordPagingIterable<ObjectNode> mockAndGetResponse() throws IOException
     {
         RecordPagingIterable<ObjectNode> mockRecordPagingIterable = Mockito.mock(RecordPagingIterable.class);
         JavaType javaType = OBJECT_MAPPER.getTypeFactory().constructParametrizedType(List.class, List.class, ObjectNode.class);
@@ -84,19 +169,7 @@ public class CustomObjectInputPluginTest
         JavaType marketoFieldsType = OBJECT_MAPPER.getTypeFactory().constructParametrizedType(List.class, List.class, MarketoField.class);
         List<MarketoField> marketoFields = OBJECT_MAPPER.readValue(this.getClass().getResourceAsStream("/fixtures/custom_object_describe_marketo_fields_full.json"), marketoFieldsType);
         Mockito.when(mockRecordPagingIterable.iterator()).thenReturn(objectNodeList.iterator());
-        Mockito.when(mockMarketoRestClient.getCustomObject(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyInt(), Mockito.anyInt())).thenReturn(mockRecordPagingIterable);
         Mockito.when(mockMarketoRestClient.describeCustomObject(Mockito.anyString())).thenReturn(marketoFields);
-        CustomObjectInputPlugin.PluginTask task = configSource.loadConfig(CustomObjectInputPlugin.PluginTask.class);
-        ServiceResponseMapper<? extends ValueLocator> mapper = customObjectInputPlugin.buildServiceResponseMapper(task);
-        RecordImporter recordImporter = mapper.createRecordImporter();
-        PageBuilder mockPageBuilder = Mockito.mock(PageBuilder.class);
-        customObjectInputPlugin.ingestServiceData(task, recordImporter, 1, mockPageBuilder);
-        Mockito.verify(mockMarketoRestClient, Mockito.times(1)).getCustomObject(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyInt(), Mockito.anyInt());
-        Mockito.verify(mockMarketoRestClient, Mockito.times(1)).describeCustomObject(Mockito.anyString());
-        Schema embulkSchema = mapper.getEmbulkSchema();
-        ArgumentCaptor<Long> longArgumentCaptor = ArgumentCaptor.forClass(Long.class);
-        Mockito.verify(mockPageBuilder, Mockito.times(3)).setLong(Mockito.eq(embulkSchema.lookupColumn("mk_id")), longArgumentCaptor.capture());
-        List<Long> allValues = longArgumentCaptor.getAllValues();
-        assertArrayEquals(new Long[]{1L, 2L, 3L}, allValues.toArray());
+        return mockRecordPagingIterable;
     }
 }

--- a/src/test/java/org/embulk/input/marketo/delegate/MarketoBaseInputPluginDelegateTest.java
+++ b/src/test/java/org/embulk/input/marketo/delegate/MarketoBaseInputPluginDelegateTest.java
@@ -33,42 +33,21 @@ public class MarketoBaseInputPluginDelegateTest
     MarketoBaseInputPluginDelegate delegate = spy(MarketoBaseInputPluginDelegate.class);
 
     @Test
-    public void testFalseSkipInvalidInput()
+    public void testInputIds()
     {
-        final boolean skipInvalid = false;
-        doReturn(getSampleResp(), getSampleResp(), Collections.emptyList()).when(service).getListsByIds(anySet());
-        Function<Set<String>, Iterable<ObjectNode>> getListIds = (ids) -> service.getListsByIds(ids);
-
-        final String[] ids = StringUtils.split("123,abc,,123.45,1002 ", ID_LIST_SEPARATOR_CHAR);
-        ConfigException exception = assertThrows(ConfigException.class, () -> delegate.getObjectsByIds(ids, skipInvalid, getListIds));
-        assertEquals("Invalid Id(s): [abc, 123.45]", exception.getMessage());
-
-        final String[] nullIds = StringUtils.split("  , ,  ,, ", ID_LIST_SEPARATOR_CHAR);
-        exception = assertThrows(ConfigException.class, () -> delegate.getObjectsByIds(nullIds, skipInvalid, getListIds));
-        assertEquals("No valid Id specified", exception.getMessage());
-
-        final String[] notExist = StringUtils.split(" 123 ,3453 ,  234234,, ", ID_LIST_SEPARATOR_CHAR);
-        exception = assertThrows(ConfigException.class, () -> delegate.getObjectsByIds(notExist, skipInvalid, getListIds));
-        assertEquals("Invalid non-existent Id(s): [123, 3453, 234234]", exception.getMessage());
-    }
-
-    @Test
-    public void testSkipInvalidInput()
-    {
-        final boolean skipInvalid = true;
         doReturn(getSampleResp(), Collections.emptyList(), Collections.emptyList()).when(service).getListsByIds(anySet());
         Function<Set<String>, Iterable<ObjectNode>> getListIds = (ids) -> service.getListsByIds(ids);
 
         final String[] ids = StringUtils.split("123,abc,,123.45,1002 ", ID_LIST_SEPARATOR_CHAR);
-        Iterable<ObjectNode> rs1 = delegate.getObjectsByIds(ids, skipInvalid, getListIds);
+        Iterable<ObjectNode> rs1 = delegate.getObjectsByIds(ids, getListIds);
         assertEquals(Lists.newArrayList(rs1).size(), 1);
 
         final String[] nullIds = StringUtils.split("  , ,  ,, ", ID_LIST_SEPARATOR_CHAR);
-        ConfigException exception = assertThrows(ConfigException.class, () -> delegate.getObjectsByIds(nullIds, skipInvalid, getListIds));
+        ConfigException exception = assertThrows(ConfigException.class, () -> delegate.getObjectsByIds(nullIds, getListIds));
         assertEquals("No valid Id specified", exception.getMessage());
 
         final String[] notExist = StringUtils.split(" 123 ,3453 ,  234234,,", ID_LIST_SEPARATOR_CHAR);
-        exception = assertThrows(ConfigException.class, () -> delegate.getObjectsByIds(notExist, skipInvalid, getListIds));
+        exception = assertThrows(ConfigException.class, () -> delegate.getObjectsByIds(notExist, getListIds));
         assertEquals("No valid Id found", exception.getMessage());
     }
 

--- a/src/test/java/org/embulk/input/marketo/delegate/MarketoBaseInputPluginDelegateTest.java
+++ b/src/test/java/org/embulk/input/marketo/delegate/MarketoBaseInputPluginDelegateTest.java
@@ -1,0 +1,81 @@
+package org.embulk.input.marketo.delegate;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.Lists;
+import org.apache.commons.lang3.StringUtils;
+import org.embulk.EmbulkTestRuntime;
+import org.embulk.config.ConfigException;
+import org.embulk.input.marketo.MarketoService;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+import static org.embulk.input.marketo.delegate.MarketoBaseInputPluginDelegate.ID_LIST_SEPARATOR_CHAR;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.anySet;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+public class MarketoBaseInputPluginDelegateTest
+{
+    @Rule
+    public EmbulkTestRuntime embulkTestRuntime = new EmbulkTestRuntime();
+    private final ObjectMapper mapper = new ObjectMapper();
+    private MarketoService service = mock(MarketoService.class);
+    MarketoBaseInputPluginDelegate delegate = spy(MarketoBaseInputPluginDelegate.class);
+
+    @Test
+    public void testFalseSkipInvalidInput()
+    {
+        final boolean skipInvalid = false;
+        doReturn(getSampleResp(), getSampleResp(), Collections.emptyList()).when(service).getListsByIds(anySet());
+        Function<Set<String>, Iterable<ObjectNode>> getListIds = (ids) -> service.getListsByIds(ids);
+
+        final String[] ids = StringUtils.split("123,abc,,123.45,1002 ", ID_LIST_SEPARATOR_CHAR);
+        ConfigException exception = assertThrows(ConfigException.class, () -> delegate.getObjectsByIds(ids, skipInvalid, getListIds));
+        assertEquals("Invalid Id(s): [abc, 123.45]", exception.getMessage());
+
+        final String[] nullIds = StringUtils.split("  , ,  ,, ", ID_LIST_SEPARATOR_CHAR);
+        exception = assertThrows(ConfigException.class, () -> delegate.getObjectsByIds(nullIds, skipInvalid, getListIds));
+        assertEquals("No valid Id specified", exception.getMessage());
+
+        final String[] notExist = StringUtils.split(" 123 ,3453 ,  234234,, ", ID_LIST_SEPARATOR_CHAR);
+        exception = assertThrows(ConfigException.class, () -> delegate.getObjectsByIds(notExist, skipInvalid, getListIds));
+        assertEquals("Invalid non-existent Id(s): [123, 3453, 234234]", exception.getMessage());
+    }
+
+    @Test
+    public void testSkipInvalidInput()
+    {
+        final boolean skipInvalid = true;
+        doReturn(getSampleResp(), Collections.emptyList(), Collections.emptyList()).when(service).getListsByIds(anySet());
+        Function<Set<String>, Iterable<ObjectNode>> getListIds = (ids) -> service.getListsByIds(ids);
+
+        final String[] ids = StringUtils.split("123,abc,,123.45,1002 ", ID_LIST_SEPARATOR_CHAR);
+        Iterable<ObjectNode> rs1 = delegate.getObjectsByIds(ids, skipInvalid, getListIds);
+        assertEquals(Lists.newArrayList(rs1).size(), 1);
+
+        final String[] nullIds = StringUtils.split("  , ,  ,, ", ID_LIST_SEPARATOR_CHAR);
+        ConfigException exception = assertThrows(ConfigException.class, () -> delegate.getObjectsByIds(nullIds, skipInvalid, getListIds));
+        assertEquals("No valid Id specified", exception.getMessage());
+
+        final String[] notExist = StringUtils.split(" 123 ,3453 ,  234234,,", ID_LIST_SEPARATOR_CHAR);
+        exception = assertThrows(ConfigException.class, () -> delegate.getObjectsByIds(notExist, skipInvalid, getListIds));
+        assertEquals("No valid Id found", exception.getMessage());
+    }
+
+    private Iterable<ObjectNode> getSampleResp()
+    {
+        List<ObjectNode> objects = new ArrayList<>();
+        objects.add(mapper.createObjectNode().put("id", 1002));
+        return objects;
+    }
+}


### PR DESCRIPTION
### Are all connections created by the plugin secure?

- [x] Does it opt secure communication standard? Such as HTTPS, SSH, SFTP, SMTP STARTTLS. If not check with CISO to decide we can deploy the plugin.
- [x] Does support both authentication and encryption appropriately? Such as: "just encrypting without authentication" that is insecure.

### Does the plugin connect only to its expected external site which the customer explicitly set in their config file?

- [x] Does NOT connect unexpected external site and our internal endpoints? Such as: “v3/job/:id/set_started” callback endpoint.

### Does NOT the plugin persist any customers' private information? Identify the private information beforehand.

- [x] Does NOT include them in (temporary) files?
- [x] Does NOT include them in log messages and exception messages?

### What kind of environments does the plugin interact with?

- [x] Does NOT execute any shell command?
- [x] Does NOT read any files on the running instance? Such as: "/etc/passwords". It’s ok to read temporary files that the plugin wrote.
- [x] Does use to create temporary files by spi.TempFileSpace utility to avoid the conflict of the file names.
- [x] Does NOT get environment variables or JVM system properties at runtime? Such as AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY in environment variables

### Does NOT the plugin use insecure libraries?

- [x] Line up all depending library so that we can identify the impact of security incident of those library if any.
- [x] Check libraries usage of the plugin; all security check list must apply to the library usages. Such as "Are all connections created by the library secure?"

### Does NOT the plugin source code repository contain kinds of credentials

- [x] API keys
- [x] Passwords

### Make sure to free up all resources allocated during Embulk transaction “committing” or “rolling back”or before.

- [x] Network (connections, pooled connections)
- [x] Memory (cache in static variables)
- [x] File (temporary files)
- [x] CPU (threads, processes)