### PR TITLE
Replace Joda-Time with java.time classes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: Build and test
+
+on: push
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with testing
+        run: ./gradlew check --console rich --info
+
+      - uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: tests
+          path: ./build/reports/tests/test
+
+      - name: JaCoCo test report
+        if: success()
+        run: ./gradlew jacocoTestReport
+
+      - uses: actions/upload-artifact@v2
+        if: success()
+        with:
+          name: jacoco
+          path: ./build/reports/jacoco/test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: java
-jdk:
-- oraclejdk8
-script:
-- ./gradlew --info check jacocoTestReport
-dist: trusty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.20 - 2020-07-17
+* [enhancement] Replace Joda-Time with java.time classes [101](https://github.com/treasure-data/embulk-input-marketo/pull/101)
+* [enhancement] Use GitHub Action instead of Travis CI [101](https://github.com/treasure-data/embulk-input-marketo/pull/101)
+
 ## 0.6.19 - 2020-07-06
 * [enhancement] Support import Lead/Member by input static List,Program IDs [100](https://github.com/treasure-data/embulk-input-marketo/pull/100)
 * [enhancement] Support string comma-separated filterValues for Custom Objects [100](https://github.com/treasure-data/embulk-input-marketo/pull/100)

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ repositories {
 configurations {
     provided
 }
-version = "0.6.19"
+version = "0.6.20"
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 

--- a/src/main/java/org/embulk/input/marketo/MarketoUtils.java
+++ b/src/main/java/org/embulk/input/marketo/MarketoUtils.java
@@ -13,11 +13,11 @@ import org.embulk.base.restclient.record.ValueLocator;
 import org.embulk.input.marketo.model.MarketoField;
 import org.embulk.spi.Exec;
 import org.embulk.spi.util.RetryExecutor;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 
 import javax.annotation.Nullable;
 
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -86,11 +86,11 @@ public class MarketoUtils
         return prefix + "_" + columnName;
     }
 
-    public static final List<DateRange> sliceRange(DateTime fromDate, DateTime toDate, int rangeSize)
+    public static final List<DateRange> sliceRange(OffsetDateTime fromDate, OffsetDateTime toDate, int rangeSize)
     {
         List<DateRange> ranges = new ArrayList<>();
         while (fromDate.isBefore(toDate)) {
-            DateTime nextToDate = fromDate.plusDays(rangeSize);
+            OffsetDateTime nextToDate = fromDate.plusDays(rangeSize);
             if (nextToDate.isAfter(toDate)) {
                 ranges.add(new DateRange(fromDate, toDate));
                 break;
@@ -113,10 +113,10 @@ public class MarketoUtils
 
     public static  final class DateRange
     {
-        public final DateTime fromDate;
-        public final DateTime toDate;
+        public final OffsetDateTime fromDate;
+        public final OffsetDateTime toDate;
 
-        public DateRange(DateTime fromDate, DateTime toDate)
+        public DateRange(OffsetDateTime fromDate, OffsetDateTime toDate)
         {
             this.fromDate = fromDate;
             this.toDate = toDate;

--- a/src/main/java/org/embulk/input/marketo/delegate/ActivityBulkExtractInputPlugin.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/ActivityBulkExtractInputPlugin.java
@@ -19,10 +19,10 @@ import org.embulk.spi.type.Types;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
-import java.sql.Date;
 import java.text.MessageFormat;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 

--- a/src/main/java/org/embulk/input/marketo/delegate/ActivityBulkExtractInputPlugin.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/ActivityBulkExtractInputPlugin.java
@@ -15,12 +15,13 @@ import org.embulk.input.marketo.MarketoServiceImpl;
 import org.embulk.input.marketo.MarketoUtils;
 import org.embulk.input.marketo.rest.MarketoRestClient;
 import org.embulk.spi.type.Types;
-import org.joda.time.DateTime;
 
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
+import java.sql.Date;
 import java.text.MessageFormat;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -140,10 +141,11 @@ public class ActivityBulkExtractInputPlugin extends MarketoBaseBulkExtractInputP
     }
 
     @Override
-    protected InputStream getExtractedStream(MarketoService service, PluginTask task, DateTime fromDate, DateTime toDate)
+    protected InputStream getExtractedStream(MarketoService service, PluginTask task, OffsetDateTime fromDate, OffsetDateTime toDate)
     {
         try {
-            return new FileInputStream(service.extractAllActivity(task.getActTypeIds(), fromDate.toDate(), toDate.toDate(), task.getPollingIntervalSecond(), task.getBulkJobTimeoutSecond()));
+            return new FileInputStream(service.extractAllActivity(task.getActTypeIds(), Date.from(fromDate.toInstant()),
+                    Date.from(toDate.toInstant()), task.getPollingIntervalSecond(), task.getBulkJobTimeoutSecond()));
         }
         catch (FileNotFoundException e) {
             throw new RuntimeException("Exception when trying to extract activity", e);

--- a/src/main/java/org/embulk/input/marketo/delegate/LeadBulkExtractInputPlugin.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/LeadBulkExtractInputPlugin.java
@@ -14,8 +14,8 @@ import org.slf4j.Logger;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
-import java.sql.Date;
 import java.time.OffsetDateTime;
+import java.util.Date;
 import java.util.List;
 
 /**

--- a/src/main/java/org/embulk/input/marketo/delegate/LeadBulkExtractInputPlugin.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/LeadBulkExtractInputPlugin.java
@@ -9,12 +9,13 @@ import org.embulk.input.marketo.MarketoService;
 import org.embulk.input.marketo.MarketoServiceImpl;
 import org.embulk.input.marketo.rest.MarketoRestClient;
 import org.embulk.spi.Exec;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
+import java.sql.Date;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 /**
@@ -43,11 +44,12 @@ public class LeadBulkExtractInputPlugin extends MarketoBaseBulkExtractInputPlugi
     }
 
     @Override
-    protected InputStream getExtractedStream(MarketoService service, PluginTask task, DateTime fromDate, DateTime toDate)
+    protected InputStream getExtractedStream(MarketoService service, PluginTask task, OffsetDateTime fromDate, OffsetDateTime toDate)
     {
         try {
             List<String> fieldNames = task.getExtractedFields();
-            return new FileInputStream(service.extractLead(fromDate.toDate(), toDate.toDate(), fieldNames, task.getIncrementalColumn().orNull(), task.getPollingIntervalSecond(), task.getBulkJobTimeoutSecond()));
+            return new FileInputStream(service.extractLead(Date.from(fromDate.toInstant()), Date.from(toDate.toInstant()),
+                    fieldNames, task.getIncrementalColumn().orNull(), task.getPollingIntervalSecond(), task.getBulkJobTimeoutSecond()));
         }
         catch (FileNotFoundException e) {
             throw new RuntimeException("File not found", e);

--- a/src/main/java/org/embulk/input/marketo/delegate/MarketoBaseBulkExtractInputPlugin.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/MarketoBaseBulkExtractInputPlugin.java
@@ -120,7 +120,6 @@ public abstract class MarketoBaseBulkExtractInputPlugin<T extends MarketoBaseBul
         task.setToDate(Optional.of(Date.from(toDate.toInstant())));
     }
 
-    //TODO RENAME
     public OffsetDateTime getToDate(T task)
     {
         Date fromDate = task.getFromDate();

--- a/src/main/java/org/embulk/input/marketo/delegate/MarketoBaseBulkExtractInputPlugin.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/MarketoBaseBulkExtractInputPlugin.java
@@ -38,7 +38,7 @@ import java.io.InputStream;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -124,7 +124,7 @@ public abstract class MarketoBaseBulkExtractInputPlugin<T extends MarketoBaseBul
     public OffsetDateTime getToDate(T task)
     {
         Date fromDate = task.getFromDate();
-        OffsetDateTime dateTime = fromDate.toInstant().atOffset(ZoneOffset.UTC);
+        OffsetDateTime dateTime = OffsetDateTime.ofInstant(fromDate.toInstant(), ZoneId.systemDefault());
         OffsetDateTime toDate = dateTime.plusDays(task.getFetchDays());
         if (toDate.isAfter(task.getJobStartTime())) {
             //Lock down to date
@@ -236,10 +236,10 @@ public abstract class MarketoBaseBulkExtractInputPlugin<T extends MarketoBaseBul
 
     private LineDecoderIterator getLineDecoderIterator(T task)
     {
-        final OffsetDateTime fromDate = task.getFromDate().toInstant().atOffset(ZoneOffset.UTC);
+        final OffsetDateTime fromDate = OffsetDateTime.ofInstant(task.getFromDate().toInstant(), ZoneId.systemDefault());
         final OffsetDateTime toDate = task.getToDate().isPresent() ?
-                task.getToDate().get().toInstant().atOffset(ZoneOffset.UTC) :
-                OffsetDateTime.now(ZoneOffset.UTC);
+                OffsetDateTime.ofInstant(task.getToDate().get().toInstant(), ZoneId.systemDefault()) :
+                OffsetDateTime.now();
         List<MarketoUtils.DateRange> dateRanges = MarketoUtils.sliceRange(fromDate, toDate, MARKETO_MAX_RANGE_EXTRACT);
         final Iterator<MarketoUtils.DateRange> iterator = dateRanges.iterator();
         return new LineDecoderIterator(iterator, task);

--- a/src/main/java/org/embulk/input/marketo/delegate/MarketoBaseBulkExtractInputPlugin.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/MarketoBaseBulkExtractInputPlugin.java
@@ -120,6 +120,7 @@ public abstract class MarketoBaseBulkExtractInputPlugin<T extends MarketoBaseBul
         task.setToDate(Optional.of(Date.from(toDate.toInstant())));
     }
 
+    //TODO RENAME
     public OffsetDateTime getToDate(T task)
     {
         Date fromDate = task.getFromDate();

--- a/src/main/java/org/embulk/input/marketo/delegate/MarketoBaseBulkExtractInputPlugin.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/MarketoBaseBulkExtractInputPlugin.java
@@ -39,6 +39,7 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -107,7 +108,7 @@ public abstract class MarketoBaseBulkExtractInputPlugin<T extends MarketoBaseBul
         if (task.getFromDate() == null) {
             throw new ConfigException("From date is required for Bulk Extract");
         }
-        if (task.getFromDate().getTime() >= task.getJobStartTime().toInstant().toEpochMilli()) {
+        if (task.getFromDate().getTime() >= OffsetDateTime.parse(task.getJobStartTime(), DateTimeFormatter.ISO_OFFSET_DATE_TIME).toInstant().toEpochMilli()) {
             throw new ConfigException("From date can't not be in future");
         }
         if (task.getIncremental()
@@ -123,11 +124,12 @@ public abstract class MarketoBaseBulkExtractInputPlugin<T extends MarketoBaseBul
     public OffsetDateTime getToDate(T task)
     {
         Date fromDate = task.getFromDate();
+        final OffsetDateTime jobStartTime = OffsetDateTime.parse(task.getJobStartTime(), DateTimeFormatter.ISO_OFFSET_DATE_TIME);
         OffsetDateTime dateTime = OffsetDateTime.ofInstant(fromDate.toInstant(), ZoneOffset.UTC);
         OffsetDateTime toDate = dateTime.plusDays(task.getFetchDays());
-        if (toDate.isAfter(task.getJobStartTime())) {
+        if (toDate.isAfter(jobStartTime)) {
             //Lock down to date
-            toDate = task.getJobStartTime();
+            toDate = jobStartTime;
         }
         return toDate;
     }

--- a/src/main/java/org/embulk/input/marketo/delegate/MarketoBaseBulkExtractInputPlugin.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/MarketoBaseBulkExtractInputPlugin.java
@@ -38,7 +38,7 @@ import java.io.InputStream;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -123,7 +123,7 @@ public abstract class MarketoBaseBulkExtractInputPlugin<T extends MarketoBaseBul
     public OffsetDateTime getToDate(T task)
     {
         Date fromDate = task.getFromDate();
-        OffsetDateTime dateTime = OffsetDateTime.ofInstant(fromDate.toInstant(), ZoneId.systemDefault());
+        OffsetDateTime dateTime = OffsetDateTime.ofInstant(fromDate.toInstant(), ZoneOffset.UTC);
         OffsetDateTime toDate = dateTime.plusDays(task.getFetchDays());
         if (toDate.isAfter(task.getJobStartTime())) {
             //Lock down to date
@@ -235,10 +235,10 @@ public abstract class MarketoBaseBulkExtractInputPlugin<T extends MarketoBaseBul
 
     private LineDecoderIterator getLineDecoderIterator(T task)
     {
-        final OffsetDateTime fromDate = OffsetDateTime.ofInstant(task.getFromDate().toInstant(), ZoneId.systemDefault());
+        final OffsetDateTime fromDate = OffsetDateTime.ofInstant(task.getFromDate().toInstant(), ZoneOffset.UTC);
         final OffsetDateTime toDate = task.getToDate().isPresent() ?
-                OffsetDateTime.ofInstant(task.getToDate().get().toInstant(), ZoneId.systemDefault()) :
-                OffsetDateTime.now();
+                OffsetDateTime.ofInstant(task.getToDate().get().toInstant(), ZoneOffset.UTC) :
+                OffsetDateTime.now(ZoneOffset.UTC);
         List<MarketoUtils.DateRange> dateRanges = MarketoUtils.sliceRange(fromDate, toDate, MARKETO_MAX_RANGE_EXTRACT);
         final Iterator<MarketoUtils.DateRange> iterator = dateRanges.iterator();
         return new LineDecoderIterator(iterator, task);

--- a/src/main/java/org/embulk/input/marketo/delegate/MarketoBaseInputPluginDelegate.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/MarketoBaseInputPluginDelegate.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -54,9 +55,9 @@ public abstract class MarketoBaseInputPluginDelegate<T extends MarketoBaseInputP
         @ConfigDefault("true")
         Boolean getIncremental();
 
-        OffsetDateTime getJobStartTime();
+        String getJobStartTime();
 
-        void setJobStartTime(OffsetDateTime dateTime);
+        void setJobStartTime(String dateTime);
     }
 
     @Override
@@ -68,7 +69,7 @@ public abstract class MarketoBaseInputPluginDelegate<T extends MarketoBaseInputP
     @Override
     public void validateInputTask(T task)
     {
-        task.setJobStartTime(OffsetDateTime.now(ZoneOffset.UTC));
+        task.setJobStartTime(OffsetDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
     }
 
     @Override

--- a/src/main/java/org/embulk/input/marketo/delegate/MarketoBaseInputPluginDelegate.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/MarketoBaseInputPluginDelegate.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -67,7 +68,7 @@ public abstract class MarketoBaseInputPluginDelegate<T extends MarketoBaseInputP
     @Override
     public void validateInputTask(T task)
     {
-        task.setJobStartTime(OffsetDateTime.now());
+        task.setJobStartTime(OffsetDateTime.now(ZoneOffset.UTC));
     }
 
     @Override

--- a/src/main/java/org/embulk/input/marketo/delegate/MarketoBaseInputPluginDelegate.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/MarketoBaseInputPluginDelegate.java
@@ -25,7 +25,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -68,7 +67,7 @@ public abstract class MarketoBaseInputPluginDelegate<T extends MarketoBaseInputP
     @Override
     public void validateInputTask(T task)
     {
-        task.setJobStartTime(OffsetDateTime.now(ZoneOffset.UTC));
+        task.setJobStartTime(OffsetDateTime.now());
     }
 
     @Override

--- a/src/main/java/org/embulk/input/marketo/delegate/MarketoBaseInputPluginDelegate.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/MarketoBaseInputPluginDelegate.java
@@ -21,10 +21,11 @@ import org.embulk.input.marketo.rest.MarketoRestClient;
 import org.embulk.spi.Exec;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.Schema;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -53,9 +54,9 @@ public abstract class MarketoBaseInputPluginDelegate<T extends MarketoBaseInputP
         @ConfigDefault("true")
         Boolean getIncremental();
 
-        DateTime getJobStartTime();
+        OffsetDateTime getJobStartTime();
 
-        void setJobStartTime(DateTime dateTime);
+        void setJobStartTime(OffsetDateTime dateTime);
     }
 
     @Override
@@ -67,7 +68,7 @@ public abstract class MarketoBaseInputPluginDelegate<T extends MarketoBaseInputP
     @Override
     public void validateInputTask(T task)
     {
-        task.setJobStartTime(DateTime.now());
+        task.setJobStartTime(OffsetDateTime.now(ZoneOffset.UTC));
     }
 
     @Override

--- a/src/main/java/org/embulk/input/marketo/delegate/ProgramInputPlugin.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/ProgramInputPlugin.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Optional;
 import com.google.common.collect.FluentIterable;
-
 import org.embulk.base.restclient.ServiceResponseMapper;
 import org.embulk.base.restclient.jackson.JacksonServiceResponseMapper;
 import org.embulk.base.restclient.record.RecordImporter;
@@ -21,19 +20,20 @@ import org.embulk.spi.Exec;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.Schema;
 import org.embulk.spi.type.Types;
-import org.joda.time.DateTime;
-import org.joda.time.Duration;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
 import org.slf4j.Logger;
 
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 
 public class ProgramInputPlugin extends MarketoBaseInputPluginDelegate<ProgramInputPlugin.PluginTask>
 {
-    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormat.forPattern(MarketoUtils.MARKETO_DATE_SIMPLE_DATE_FORMAT);
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern(MarketoUtils.MARKETO_DATE_SIMPLE_DATE_FORMAT);
     private final Logger logger = Exec.getLogger(getClass());
 
     public interface PluginTask extends MarketoBaseInputPluginDelegate.PluginTask
@@ -96,12 +96,14 @@ public class ProgramInputPlugin extends MarketoBaseInputPluginDelegate<ProgramIn
                     throw new ConfigException("`earliest_updated_at` is required when query by Date Range");
                 }
 
-                DateTime earliest = new DateTime(task.getEarliestUpdatedAt().get());
+                OffsetDateTime earliest = task.getEarliestUpdatedAt().isPresent() ?
+                        task.getEarliestUpdatedAt().get().toInstant().atOffset(ZoneOffset.UTC) :
+                        OffsetDateTime.now(ZoneOffset.UTC);
                 if (task.getReportDuration().isPresent()) {
                     logger.info("`report_duration` is present, Prefer `report_duration` over `latest_updated_at`");
                     // Update the latestUpdatedAt for the config
-                    DateTime latest = earliest.plus(task.getReportDuration().get());
-                    task.setLatestUpdatedAt(Optional.of(latest.toDate()));
+                    OffsetDateTime latest = earliest.plus(task.getReportDuration().get(), ChronoUnit.MILLIS);
+                    task.setLatestUpdatedAt(Optional.of(Date.from(latest.toInstant())));
                 }
 
                 // latest_updated_at is required calculate time range
@@ -109,17 +111,19 @@ public class ProgramInputPlugin extends MarketoBaseInputPluginDelegate<ProgramIn
                     throw new ConfigException("`latest_updated_at` is required when query by Date Range");
                 }
 
-                DateTime latest = new DateTime(task.getLatestUpdatedAt().get());
-                if (earliest.isAfter(DateTime.now())) {
+                OffsetDateTime latest = task.getLatestUpdatedAt().isPresent() ?
+                        task.getLatestUpdatedAt().get().toInstant().atOffset(ZoneOffset.UTC) :
+                        OffsetDateTime.now(ZoneOffset.UTC);
+                if (earliest.isAfter(OffsetDateTime.now(ZoneOffset.UTC))) {
                     throw new ConfigException(String.format("`earliest_updated_at` (%s) cannot precede the current date (%s)",
-                                    earliest.toString(DATE_FORMATTER),
-                                    (DateTime.now().toString(DATE_FORMATTER))));
+                                    earliest.format(DATE_FORMATTER),
+                                    (OffsetDateTime.now(ZoneOffset.UTC).format(DATE_FORMATTER))));
                 }
 
                 if (earliest.isAfter(latest)) {
                     throw new ConfigException(String.format("Invalid date range. `earliest_updated_at` (%s) cannot precede the `latest_updated_at` (%s).",
-                                    earliest.toString(DATE_FORMATTER),
-                                    latest.toString(DATE_FORMATTER)));
+                                    earliest.format(DATE_FORMATTER),
+                                    latest.format(DATE_FORMATTER)));
                 }
                 // if filter type is selected, filter value must be presented
                 if (task.getFilterType().isPresent() && (!task.getFilterValues().isPresent() || task.getFilterValues().get().isEmpty())) {
@@ -134,14 +138,20 @@ public class ProgramInputPlugin extends MarketoBaseInputPluginDelegate<ProgramIn
     {
         // query by date range and incremental import and not preview
         if (task.getQueryBy().isPresent() && task.getQueryBy().get() == QueryBy.DATE_RANGE && task.getIncremental() && !Exec.isPreview()) {
-            DateTime latestUpdateAt = new DateTime(task.getLatestUpdatedAt().get());
-            DateTime now = DateTime.now();
+            OffsetDateTime latestUpdateAt = task.getLatestUpdatedAt().isPresent() ?
+                    task.getLatestUpdatedAt().get().toInstant().atOffset(ZoneOffset.UTC) :
+                    OffsetDateTime.now(ZoneOffset.UTC);
+            OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
             // Do not run incremental import if latest_updated_at precede current time
             if (latestUpdateAt.isAfter(now)) {
-                logger.warn("`latest_updated_at` ({}) preceded current time ({}). Will try to import next run", latestUpdateAt.toString(DATE_FORMATTER), now.toString(DATE_FORMATTER));
+                logger.warn("`latest_updated_at` ({}) preceded current time ({}). Will try to import next run",
+                        latestUpdateAt.format(DATE_FORMATTER), now.format(DATE_FORMATTER));
 
+                OffsetDateTime earliest = task.getEarliestUpdatedAt().isPresent() ?
+                        task.getEarliestUpdatedAt().get().toInstant().atOffset(ZoneOffset.UTC) :
+                        OffsetDateTime.now(ZoneOffset.UTC);
                 TaskReport taskReport = Exec.newTaskReport();
-                taskReport.set("earliest_updated_at", new DateTime(task.getEarliestUpdatedAt().get()).toString(DATE_FORMATTER));
+                taskReport.set("earliest_updated_at", earliest.format(DATE_FORMATTER));
                 if (task.getReportDuration().isPresent()) {
                     taskReport.set("report_duration", task.getReportDuration().get());
                 }
@@ -179,14 +189,18 @@ public class ProgramInputPlugin extends MarketoBaseInputPluginDelegate<ProgramIn
         ConfigDiff configDiff = super.buildConfigDiff(task, schema, taskCount, taskReports);
         // set next next earliestUpdatedAt, latestUpdatedAt
         if (task.getQueryBy().isPresent() && task.getQueryBy().get() == QueryBy.DATE_RANGE && task.getIncremental()) {
-            DateTime earliest = new DateTime(task.getEarliestUpdatedAt().get());
-            DateTime latest = new DateTime(task.getLatestUpdatedAt().get());
+            OffsetDateTime earliest = task.getEarliestUpdatedAt().isPresent() ?
+                    task.getEarliestUpdatedAt().get().toInstant().atOffset(ZoneOffset.UTC) :
+                    OffsetDateTime.now(ZoneOffset.UTC);
+            OffsetDateTime latest = task.getLatestUpdatedAt().isPresent() ?
+                    task.getLatestUpdatedAt().get().toInstant().atOffset(ZoneOffset.UTC) :
+                    OffsetDateTime.now(ZoneOffset.UTC);
 
-            Duration d = new Duration(earliest, latest);
-            DateTime nextEarliestUpdatedAt = latest.plusSeconds(1);
+            Duration d = Duration.between(earliest, latest);
+            OffsetDateTime nextEarliestUpdatedAt = latest.plusSeconds(1);
 
-            configDiff.set("earliest_updated_at", nextEarliestUpdatedAt.toString(DATE_FORMATTER));
-            configDiff.set("report_duration", task.getReportDuration().or(d.getMillis()));
+            configDiff.set("earliest_updated_at", nextEarliestUpdatedAt.format(DATE_FORMATTER));
+            configDiff.set("report_duration", task.getReportDuration().or(d.toMillis()));
         }
         return configDiff;
     }

--- a/src/main/java/org/embulk/input/marketo/delegate/ProgramInputPlugin.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/ProgramInputPlugin.java
@@ -96,9 +96,7 @@ public class ProgramInputPlugin extends MarketoBaseInputPluginDelegate<ProgramIn
                     throw new ConfigException("`earliest_updated_at` is required when query by Date Range");
                 }
 
-                OffsetDateTime earliest = task.getEarliestUpdatedAt().isPresent() ?
-                        OffsetDateTime.ofInstant(task.getEarliestUpdatedAt().get().toInstant(), ZoneOffset.UTC) :
-                        OffsetDateTime.now(ZoneOffset.UTC);
+                OffsetDateTime earliest = OffsetDateTime.ofInstant(task.getEarliestUpdatedAt().get().toInstant(), ZoneOffset.UTC);
                 if (task.getReportDuration().isPresent()) {
                     logger.info("`report_duration` is present, Prefer `report_duration` over `latest_updated_at`");
                     // Update the latestUpdatedAt for the config
@@ -111,9 +109,7 @@ public class ProgramInputPlugin extends MarketoBaseInputPluginDelegate<ProgramIn
                     throw new ConfigException("`latest_updated_at` is required when query by Date Range");
                 }
 
-                OffsetDateTime latest = task.getLatestUpdatedAt().isPresent() ?
-                        OffsetDateTime.ofInstant(task.getLatestUpdatedAt().get().toInstant(), ZoneOffset.UTC) :
-                        OffsetDateTime.now(ZoneOffset.UTC);
+                OffsetDateTime latest = OffsetDateTime.ofInstant(task.getLatestUpdatedAt().get().toInstant(), ZoneOffset.UTC);
                 if (earliest.isAfter(OffsetDateTime.now(ZoneOffset.UTC))) {
                     throw new ConfigException(String.format("`earliest_updated_at` (%s) cannot precede the current date (%s)",
                                     earliest.format(DATE_FORMATTER),
@@ -138,18 +134,14 @@ public class ProgramInputPlugin extends MarketoBaseInputPluginDelegate<ProgramIn
     {
         // query by date range and incremental import and not preview
         if (task.getQueryBy().isPresent() && task.getQueryBy().get() == QueryBy.DATE_RANGE && task.getIncremental() && !Exec.isPreview()) {
-            OffsetDateTime latestUpdateAt = task.getLatestUpdatedAt().isPresent() ?
-                    OffsetDateTime.ofInstant(task.getLatestUpdatedAt().get().toInstant(), ZoneOffset.UTC) :
-                    OffsetDateTime.now(ZoneOffset.UTC);
+            OffsetDateTime latestUpdateAt = OffsetDateTime.ofInstant(task.getLatestUpdatedAt().get().toInstant(), ZoneOffset.UTC);
             OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
             // Do not run incremental import if latest_updated_at precede current time
             if (latestUpdateAt.isAfter(now)) {
                 logger.warn("`latest_updated_at` ({}) preceded current time ({}). Will try to import next run",
                         latestUpdateAt.format(DATE_FORMATTER), now.format(DATE_FORMATTER));
 
-                OffsetDateTime earliest = task.getEarliestUpdatedAt().isPresent() ?
-                        OffsetDateTime.ofInstant(task.getEarliestUpdatedAt().get().toInstant(), ZoneOffset.UTC) :
-                        OffsetDateTime.now(ZoneOffset.UTC);
+                OffsetDateTime earliest = OffsetDateTime.ofInstant(task.getEarliestUpdatedAt().get().toInstant(), ZoneOffset.UTC);
                 TaskReport taskReport = Exec.newTaskReport();
                 taskReport.set("earliest_updated_at", earliest.format(DATE_FORMATTER));
                 if (task.getReportDuration().isPresent()) {

--- a/src/main/java/org/embulk/input/marketo/delegate/ProgramInputPlugin.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/ProgramInputPlugin.java
@@ -139,7 +139,7 @@ public class ProgramInputPlugin extends MarketoBaseInputPluginDelegate<ProgramIn
         // query by date range and incremental import and not preview
         if (task.getQueryBy().isPresent() && task.getQueryBy().get() == QueryBy.DATE_RANGE && task.getIncremental() && !Exec.isPreview()) {
             OffsetDateTime latestUpdateAt = task.getLatestUpdatedAt().isPresent() ?
-                    OffsetDateTime.ofInstant(task.getLatestUpdatedAt().get().toInstant(), ZoneId.systemDefault()):
+                    OffsetDateTime.ofInstant(task.getLatestUpdatedAt().get().toInstant(), ZoneId.systemDefault()) :
                     OffsetDateTime.now(ZoneId.systemDefault());
             OffsetDateTime now = OffsetDateTime.now(ZoneId.systemDefault());
             // Do not run incremental import if latest_updated_at precede current time

--- a/src/main/java/org/embulk/input/marketo/delegate/ProgramInputPlugin.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/ProgramInputPlugin.java
@@ -24,7 +24,7 @@ import org.slf4j.Logger;
 
 import java.time.Duration;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
@@ -97,8 +97,8 @@ public class ProgramInputPlugin extends MarketoBaseInputPluginDelegate<ProgramIn
                 }
 
                 OffsetDateTime earliest = task.getEarliestUpdatedAt().isPresent() ?
-                        OffsetDateTime.ofInstant(task.getEarliestUpdatedAt().get().toInstant(), ZoneId.systemDefault()) :
-                        OffsetDateTime.now(ZoneId.systemDefault());
+                        OffsetDateTime.ofInstant(task.getEarliestUpdatedAt().get().toInstant(), ZoneOffset.UTC) :
+                        OffsetDateTime.now(ZoneOffset.UTC);
                 if (task.getReportDuration().isPresent()) {
                     logger.info("`report_duration` is present, Prefer `report_duration` over `latest_updated_at`");
                     // Update the latestUpdatedAt for the config
@@ -112,12 +112,12 @@ public class ProgramInputPlugin extends MarketoBaseInputPluginDelegate<ProgramIn
                 }
 
                 OffsetDateTime latest = task.getLatestUpdatedAt().isPresent() ?
-                        OffsetDateTime.ofInstant(task.getLatestUpdatedAt().get().toInstant(), ZoneId.systemDefault()) :
-                        OffsetDateTime.now();
-                if (earliest.isAfter(OffsetDateTime.now())) {
+                        OffsetDateTime.ofInstant(task.getLatestUpdatedAt().get().toInstant(), ZoneOffset.UTC) :
+                        OffsetDateTime.now(ZoneOffset.UTC);
+                if (earliest.isAfter(OffsetDateTime.now(ZoneOffset.UTC))) {
                     throw new ConfigException(String.format("`earliest_updated_at` (%s) cannot precede the current date (%s)",
                                     earliest.format(DATE_FORMATTER),
-                                    (OffsetDateTime.now().format(DATE_FORMATTER))));
+                                    (OffsetDateTime.now(ZoneOffset.UTC).format(DATE_FORMATTER))));
                 }
 
                 if (earliest.isAfter(latest)) {
@@ -139,17 +139,17 @@ public class ProgramInputPlugin extends MarketoBaseInputPluginDelegate<ProgramIn
         // query by date range and incremental import and not preview
         if (task.getQueryBy().isPresent() && task.getQueryBy().get() == QueryBy.DATE_RANGE && task.getIncremental() && !Exec.isPreview()) {
             OffsetDateTime latestUpdateAt = task.getLatestUpdatedAt().isPresent() ?
-                    OffsetDateTime.ofInstant(task.getLatestUpdatedAt().get().toInstant(), ZoneId.systemDefault()) :
-                    OffsetDateTime.now(ZoneId.systemDefault());
-            OffsetDateTime now = OffsetDateTime.now(ZoneId.systemDefault());
+                    OffsetDateTime.ofInstant(task.getLatestUpdatedAt().get().toInstant(), ZoneOffset.UTC) :
+                    OffsetDateTime.now(ZoneOffset.UTC);
+            OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
             // Do not run incremental import if latest_updated_at precede current time
             if (latestUpdateAt.isAfter(now)) {
                 logger.warn("`latest_updated_at` ({}) preceded current time ({}). Will try to import next run",
                         latestUpdateAt.format(DATE_FORMATTER), now.format(DATE_FORMATTER));
 
                 OffsetDateTime earliest = task.getEarliestUpdatedAt().isPresent() ?
-                        OffsetDateTime.ofInstant(task.getEarliestUpdatedAt().get().toInstant(), ZoneId.systemDefault()) :
-                        OffsetDateTime.now(ZoneId.systemDefault());
+                        OffsetDateTime.ofInstant(task.getEarliestUpdatedAt().get().toInstant(), ZoneOffset.UTC) :
+                        OffsetDateTime.now(ZoneOffset.UTC);
                 TaskReport taskReport = Exec.newTaskReport();
                 taskReport.set("earliest_updated_at", earliest.format(DATE_FORMATTER));
                 if (task.getReportDuration().isPresent()) {
@@ -190,11 +190,11 @@ public class ProgramInputPlugin extends MarketoBaseInputPluginDelegate<ProgramIn
         // set next next earliestUpdatedAt, latestUpdatedAt
         if (task.getQueryBy().isPresent() && task.getQueryBy().get() == QueryBy.DATE_RANGE && task.getIncremental()) {
             OffsetDateTime earliest = task.getEarliestUpdatedAt().isPresent() ?
-                    OffsetDateTime.ofInstant(task.getEarliestUpdatedAt().get().toInstant(), ZoneId.systemDefault()) :
-                    OffsetDateTime.now();
+                    OffsetDateTime.ofInstant(task.getEarliestUpdatedAt().get().toInstant(), ZoneOffset.UTC) :
+                    OffsetDateTime.now(ZoneOffset.UTC);
             OffsetDateTime latest = task.getLatestUpdatedAt().isPresent() ?
-                    OffsetDateTime.ofInstant(task.getLatestUpdatedAt().get().toInstant(), ZoneId.systemDefault()) :
-                    OffsetDateTime.now();
+                    OffsetDateTime.ofInstant(task.getLatestUpdatedAt().get().toInstant(), ZoneOffset.UTC) :
+                    OffsetDateTime.now(ZoneOffset.UTC);
 
             Duration d = Duration.between(earliest, latest);
             OffsetDateTime nextEarliestUpdatedAt = latest.plusSeconds(1);

--- a/src/test/java/org/embulk/input/marketo/MarketoUtilsTest.java
+++ b/src/test/java/org/embulk/input/marketo/MarketoUtilsTest.java
@@ -77,7 +77,7 @@ public class MarketoUtilsTest
     @Test
     public void sliceRange()
     {
-        OffsetDateTime startDate = OffsetDateTime.ofInstant(Instant.ofEpochSecond(1507369760000L), ZoneId.systemDefault());
+        OffsetDateTime startDate = OffsetDateTime.ofInstant(Instant.ofEpochMilli(1507369760000L), ZoneId.systemDefault());
         List<MarketoUtils.DateRange> dateRanges1 = MarketoUtils.sliceRange(startDate, startDate.plusDays(7), 2);
         assertEquals(4, dateRanges1.size());
         assertEquals(startDate.plusDays(7), dateRanges1.get(3).toDate);

--- a/src/test/java/org/embulk/input/marketo/MarketoUtilsTest.java
+++ b/src/test/java/org/embulk/input/marketo/MarketoUtilsTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 
 import java.time.Instant;
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -77,7 +77,7 @@ public class MarketoUtilsTest
     @Test
     public void sliceRange()
     {
-        OffsetDateTime startDate = OffsetDateTime.ofInstant(Instant.ofEpochSecond(1507369760000L), ZoneOffset.UTC);
+        OffsetDateTime startDate = OffsetDateTime.ofInstant(Instant.ofEpochSecond(1507369760000L), ZoneId.systemDefault());
         List<MarketoUtils.DateRange> dateRanges1 = MarketoUtils.sliceRange(startDate, startDate.plusDays(7), 2);
         assertEquals(4, dateRanges1.size());
         assertEquals(startDate.plusDays(7), dateRanges1.get(3).toDate);

--- a/src/test/java/org/embulk/input/marketo/MarketoUtilsTest.java
+++ b/src/test/java/org/embulk/input/marketo/MarketoUtilsTest.java
@@ -5,9 +5,11 @@ import org.embulk.base.restclient.record.ValueLocator;
 import org.embulk.input.marketo.model.MarketoField;
 import org.embulk.spi.Column;
 import org.embulk.spi.type.Types;
-import org.joda.time.DateTime;
 import org.junit.Test;
 
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -20,7 +22,7 @@ import static org.junit.Assert.assertFalse;
 public class MarketoUtilsTest
 {
     @Test
-    public void buildDynamicResponseMapper() throws Exception
+    public void buildDynamicResponseMapper()
     {
         List<MarketoField> marketoFields = new ArrayList<>();
         marketoFields.add(new MarketoField("marketoField1", "text"));
@@ -40,7 +42,7 @@ public class MarketoUtilsTest
     }
 
     @Test
-    public void getFieldNameFromMarketoFields() throws Exception
+    public void getFieldNameFromMarketoFields()
     {
         List<MarketoField> marketoFields = new ArrayList<>();
         marketoFields.add(new MarketoField("marketoField1", "text"));
@@ -52,30 +54,30 @@ public class MarketoUtilsTest
     }
 
     @Test
-    public void buildColumnName() throws Exception
+    public void buildColumnName()
     {
         String columnName = MarketoUtils.buildColumnName("prefix", "columnName");
         assertEquals("prefix_columnName", columnName);
     }
 
     @Test
-    public void getIdentityEndPoint() throws Exception
+    public void getIdentityEndPoint()
     {
         String identityEndPoint = MarketoUtils.getIdentityEndPoint("accountId");
         assertEquals("https://accountId.mktorest.com/identity", identityEndPoint);
     }
 
     @Test
-    public void getEndPoint() throws Exception
+    public void getEndPoint()
     {
         String endPoint = MarketoUtils.getEndPoint("accountId");
         assertEquals("https://accountId.mktorest.com", endPoint);
     }
 
     @Test
-    public void sliceRange() throws Exception
+    public void sliceRange()
     {
-        DateTime startDate = new DateTime(1507369760000L);
+        OffsetDateTime startDate = OffsetDateTime.ofInstant(Instant.ofEpochSecond(1507369760000L), ZoneOffset.UTC);
         List<MarketoUtils.DateRange> dateRanges1 = MarketoUtils.sliceRange(startDate, startDate.plusDays(7), 2);
         assertEquals(4, dateRanges1.size());
         assertEquals(startDate.plusDays(7), dateRanges1.get(3).toDate);

--- a/src/test/java/org/embulk/input/marketo/MarketoUtilsTest.java
+++ b/src/test/java/org/embulk/input/marketo/MarketoUtilsTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 
 import java.time.Instant;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -77,7 +77,7 @@ public class MarketoUtilsTest
     @Test
     public void sliceRange()
     {
-        OffsetDateTime startDate = OffsetDateTime.ofInstant(Instant.ofEpochMilli(1507369760000L), ZoneId.systemDefault());
+        OffsetDateTime startDate = OffsetDateTime.ofInstant(Instant.ofEpochMilli(1507369760000L), ZoneOffset.UTC);
         List<MarketoUtils.DateRange> dateRanges1 = MarketoUtils.sliceRange(startDate, startDate.plusDays(7), 2);
         assertEquals(4, dateRanges1.size());
         assertEquals(startDate.plusDays(7), dateRanges1.get(3).toDate);

--- a/src/test/java/org/embulk/input/marketo/delegate/ActivityBulkExtractInputPluginTest.java
+++ b/src/test/java/org/embulk/input/marketo/delegate/ActivityBulkExtractInputPluginTest.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -100,7 +100,7 @@ public class ActivityBulkExtractInputPluginTest
     {
         ActivityBulkExtractInputPlugin.PluginTask task = configSource.loadConfig(ActivityBulkExtractInputPlugin.PluginTask.class);
 
-        OffsetDateTime startDate = OffsetDateTime.ofInstant(task.getFromDate().toInstant(), ZoneId.systemDefault());
+        OffsetDateTime startDate = OffsetDateTime.ofInstant(task.getFromDate().toInstant(), ZoneOffset.UTC);
         List<Integer> activityTypeIds = new ArrayList<>();
 
         PageBuilder pageBuilder = Mockito.mock(PageBuilder.class);

--- a/src/test/java/org/embulk/input/marketo/delegate/ActivityBulkExtractInputPluginTest.java
+++ b/src/test/java/org/embulk/input/marketo/delegate/ActivityBulkExtractInputPluginTest.java
@@ -18,7 +18,6 @@ import org.embulk.input.marketo.rest.RecordPagingIterable;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.Schema;
-import org.joda.time.DateTime;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -30,6 +29,8 @@ import org.mockito.Mockito;
 import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -99,7 +100,7 @@ public class ActivityBulkExtractInputPluginTest
     {
         ActivityBulkExtractInputPlugin.PluginTask task = configSource.loadConfig(ActivityBulkExtractInputPlugin.PluginTask.class);
 
-        DateTime startDate = new DateTime(task.getFromDate());
+        OffsetDateTime startDate = OffsetDateTime.ofInstant(task.getFromDate().toInstant(), ZoneId.systemDefault());
         List<Integer> activityTypeIds = new ArrayList<>();
 
         PageBuilder pageBuilder = Mockito.mock(PageBuilder.class);
@@ -118,11 +119,11 @@ public class ActivityBulkExtractInputPluginTest
         Mockito.verify(mockMarketoRestclient, Mockito.times(1)).waitActitvityExportJobComplete(Mockito.eq(exportId1), Mockito.eq(task.getPollingIntervalSecond()), Mockito.eq(task.getBulkJobTimeoutSecond()));
         Mockito.verify(mockMarketoRestclient, Mockito.times(1)).startActitvityBulkExtract(Mockito.eq(exportId2));
         Mockito.verify(mockMarketoRestclient, Mockito.times(1)).waitActitvityExportJobComplete(Mockito.eq(exportId2), Mockito.eq(task.getPollingIntervalSecond()), Mockito.eq(task.getBulkJobTimeoutSecond()));
-        Mockito.verify(mockMarketoRestclient, Mockito.times(1)).createActivityExtract(activityTypeIds, startDate.toDate(), startDate.plusDays(30).toDate());
-        DateTime startDate2 = startDate.plusDays(30).plusSeconds(1);
-        Mockito.verify(mockMarketoRestclient, Mockito.times(1)).createActivityExtract(activityTypeIds, startDate2.toDate(), startDate.plusDays(task.getFetchDays()).toDate());
+        Mockito.verify(mockMarketoRestclient, Mockito.times(1)).createActivityExtract(activityTypeIds, Date.from(startDate.toInstant()), Date.from(startDate.plusDays(30).toInstant()));
+        OffsetDateTime startDate2 = startDate.plusDays(30).plusSeconds(1);
+        Mockito.verify(mockMarketoRestclient, Mockito.times(1)).createActivityExtract(activityTypeIds, Date.from(startDate2.toInstant()), Date.from(startDate.plusDays(task.getFetchDays()).toInstant()));
         ConfigDiff configDiff = activityBulkExtractInputPlugin.buildConfigDiff(task, Mockito.mock(Schema.class), 1, Arrays.asList(taskReport));
         DateFormat df = new SimpleDateFormat(MarketoUtils.MARKETO_DATE_SIMPLE_DATE_FORMAT);
-        Assert.assertEquals(df.format(startDate.plusDays(task.getFetchDays()).toDate()), configDiff.get(String.class, "from_date"));
+        Assert.assertEquals(df.format(Date.from(startDate.plusDays(task.getFetchDays()).toInstant())), configDiff.get(String.class, "from_date"));
     }
 }

--- a/src/test/java/org/embulk/input/marketo/delegate/LeadBulkExtractInputPluginTest.java
+++ b/src/test/java/org/embulk/input/marketo/delegate/LeadBulkExtractInputPluginTest.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -65,7 +65,7 @@ public class LeadBulkExtractInputPluginTest
     public void testRun() throws InterruptedException, IOException
     {
         LeadBulkExtractInputPlugin.PluginTask task = configSource.loadConfig(LeadBulkExtractInputPlugin.PluginTask.class);
-        OffsetDateTime startDate = OffsetDateTime.ofInstant(task.getFromDate().toInstant(), ZoneId.systemDefault());
+        OffsetDateTime startDate = OffsetDateTime.ofInstant(task.getFromDate().toInstant(), ZoneOffset.UTC);
         PageBuilder pageBuilder = Mockito.mock(PageBuilder.class);
         String exportId1 = "exportId1";
         String exportId2 = "exportId2";

--- a/src/test/java/org/embulk/input/marketo/delegate/LeadBulkExtractInputPluginTest.java
+++ b/src/test/java/org/embulk/input/marketo/delegate/LeadBulkExtractInputPluginTest.java
@@ -16,7 +16,6 @@ import org.embulk.input.marketo.rest.MarketoRestClient;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.Schema;
-import org.joda.time.DateTime;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -27,6 +26,8 @@ import org.mockito.Mockito;
 import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -64,7 +65,7 @@ public class LeadBulkExtractInputPluginTest
     public void testRun() throws InterruptedException, IOException
     {
         LeadBulkExtractInputPlugin.PluginTask task = configSource.loadConfig(LeadBulkExtractInputPlugin.PluginTask.class);
-        DateTime startDate = new DateTime(task.getFromDate());
+        OffsetDateTime startDate = OffsetDateTime.ofInstant(task.getFromDate().toInstant(), ZoneId.systemDefault());
         PageBuilder pageBuilder = Mockito.mock(PageBuilder.class);
         String exportId1 = "exportId1";
         String exportId2 = "exportId2";
@@ -86,14 +87,16 @@ public class LeadBulkExtractInputPluginTest
         Mockito.verify(mockMarketoRestclient, Mockito.times(1)).startLeadBulkExtract(eq(exportId2));
         Mockito.verify(mockMarketoRestclient, Mockito.times(1)).waitLeadExportJobComplete(eq(exportId2), eq(task.getPollingIntervalSecond()), eq(task.getBulkJobTimeoutSecond()));
         String filterField = "createdAt";
-        Mockito.verify(mockMarketoRestclient, Mockito.times(1)).createLeadBulkExtract(startDate.toDate(), startDate.plusDays(30).toDate(), fieldNameFromMarketoFields, filterField);
-        DateTime startDate2 = startDate.plusDays(30).plusSeconds(1);
-        Mockito.verify(mockMarketoRestclient, Mockito.times(1)).createLeadBulkExtract(startDate2.toDate(), startDate.plusDays(task.getFetchDays()).toDate(), fieldNameFromMarketoFields, filterField);
+        Mockito.verify(mockMarketoRestclient, Mockito.times(1)).createLeadBulkExtract(Date.from(startDate.toInstant()),
+                Date.from(startDate.plusDays(30).toInstant()), fieldNameFromMarketoFields, filterField);
+        OffsetDateTime startDate2 = startDate.plusDays(30).plusSeconds(1);
+        Mockito.verify(mockMarketoRestclient, Mockito.times(1)).createLeadBulkExtract(Date.from(startDate2.toInstant()),
+                Date.from(startDate.plusDays(task.getFetchDays()).toInstant()), fieldNameFromMarketoFields, filterField);
         List<Long> leadIds = argumentCaptor.getAllValues();
         Assert.assertEquals(19, leadIds.size());
         ConfigDiff configDiff = bulkExtractInputPlugin.buildConfigDiff(task, Mockito.mock(Schema.class), 1, Arrays.asList(taskReport));
         DateFormat df = new SimpleDateFormat(MarketoUtils.MARKETO_DATE_SIMPLE_DATE_FORMAT);
-        Assert.assertEquals(df.format(startDate.plusDays(task.getFetchDays()).toDate()), configDiff.get(String.class, "from_date"));
+        Assert.assertEquals(df.format(Date.from(startDate.plusDays(task.getFetchDays()).toInstant())), configDiff.get(String.class, "from_date"));
         Assert.assertArrayEquals(new Long[]{102488L, 102456L, 102445L, 102439L, 102471L, 102503L, 102424L, 102473L, 102505L, 102492L, 102495L, 102452L, 102435L, 102467L, 102420L, 102496L, 102448L, 102499L, 102431L}, leadIds.toArray());
     }
 }

--- a/src/test/java/org/embulk/input/marketo/delegate/MarketoBaseBulkExtractInputPluginTest.java
+++ b/src/test/java/org/embulk/input/marketo/delegate/MarketoBaseBulkExtractInputPluginTest.java
@@ -1,7 +1,6 @@
 package org.embulk.input.marketo.delegate;
 
 import com.google.common.base.Optional;
-
 import org.embulk.EmbulkTestRuntime;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigException;
@@ -21,6 +20,9 @@ import org.mockito.Mockito;
 import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Date;
 
@@ -96,7 +98,7 @@ public class MarketoBaseBulkExtractInputPluginTest
     public void validateInputTaskToDateLessThanJobStartTime()
     {
         Date fromDate = new Date(1504224000000L);
-        DateTime jobStartTime = new DateTime(1506842144000L);
+        OffsetDateTime jobStartTime = OffsetDateTime.ofInstant(Instant.ofEpochSecond(1506842144000L), ZoneOffset.UTC);
         MarketoBaseBulkExtractInputPlugin.PluginTask pluginTask = Mockito.mock(MarketoBaseBulkExtractInputPlugin.PluginTask.class);
         Mockito.when(pluginTask.getFromDate()).thenReturn(fromDate);
         Mockito.when(pluginTask.getJobStartTime()).thenReturn(jobStartTime);
@@ -111,7 +113,7 @@ public class MarketoBaseBulkExtractInputPluginTest
     public void validateInputTaskFromDateMoreThanJobStartTime()
     {
         Date fromDate = new Date(1507619744000L);
-        DateTime jobStartTime = new DateTime(1506842144000L);
+        OffsetDateTime jobStartTime = OffsetDateTime.ofInstant(Instant.ofEpochSecond(1506842144000L), ZoneOffset.UTC);
         MarketoBaseBulkExtractInputPlugin.PluginTask pluginTask = Mockito.mock(MarketoBaseBulkExtractInputPlugin.PluginTask.class);
         Mockito.when(pluginTask.getFromDate()).thenReturn(fromDate);
         Mockito.when(pluginTask.getJobStartTime()).thenReturn(jobStartTime);
@@ -129,7 +131,7 @@ public class MarketoBaseBulkExtractInputPluginTest
     public void validateInputTaskToDateMoreThanJobStartTime()
     {
         Date fromDate = new Date(1504224000000L);
-        DateTime jobStartTime = new DateTime(1504396800000L);
+        OffsetDateTime jobStartTime = OffsetDateTime.ofInstant(Instant.ofEpochSecond(1504396800000L), ZoneOffset.UTC);
         MarketoBaseBulkExtractInputPlugin.PluginTask pluginTask = Mockito.mock(MarketoBaseBulkExtractInputPlugin.PluginTask.class);
         Mockito.when(pluginTask.getFromDate()).thenReturn(fromDate);
         Mockito.when(pluginTask.getFetchDays()).thenReturn(7);
@@ -137,24 +139,24 @@ public class MarketoBaseBulkExtractInputPluginTest
         baseBulkExtractInputPlugin.validateInputTask(pluginTask);
         ArgumentCaptor<Optional<Date>> toDateArgumentCaptor = ArgumentCaptor.forClass(Optional.class);
         Mockito.verify(pluginTask, Mockito.times(1)).setToDate(toDateArgumentCaptor.capture());
-        assertEquals(jobStartTime.getMillis(), toDateArgumentCaptor.getValue().get().getTime());
+        assertEquals(jobStartTime.toInstant().toEpochMilli(), toDateArgumentCaptor.getValue().get().getTime());
     }
 
     @Test
-    public void getToDate() throws Exception
+    public void getToDate()
     {
         DateTime date = new DateTime(1505033728000L);
-        DateTime jobStartTime = new DateTime(1507625728000L);
+        OffsetDateTime jobStartTime = OffsetDateTime.ofInstant(Instant.ofEpochSecond(1507625728000L), ZoneOffset.UTC);
         MarketoBaseBulkExtractInputPlugin.PluginTask pluginTask = Mockito.mock(MarketoInputPluginDelegate.PluginTask.class);
         Mockito.when(pluginTask.getFromDate()).thenReturn(date.toDate());
         Mockito.when(pluginTask.getFetchDays()).thenReturn(30);
         Mockito.when(pluginTask.getJobStartTime()).thenReturn(jobStartTime);
-        DateTime toDate = baseBulkExtractInputPlugin.getToDate(pluginTask);
+        OffsetDateTime toDate = baseBulkExtractInputPlugin.getToDate(pluginTask);
         assertEquals(toDate, jobStartTime);
     }
 
     @Test
-    public void buildConfigDiff() throws Exception
+    public void buildConfigDiff()
     {
         TaskReport taskReport1 = Mockito.mock(TaskReport.class);
         MarketoInputPluginDelegate.PluginTask task = Mockito.mock(MarketoInputPluginDelegate.PluginTask.class);

--- a/src/test/java/org/embulk/input/marketo/delegate/MarketoBaseBulkExtractInputPluginTest.java
+++ b/src/test/java/org/embulk/input/marketo/delegate/MarketoBaseBulkExtractInputPluginTest.java
@@ -21,7 +21,7 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Date;
 
@@ -97,7 +97,7 @@ public class MarketoBaseBulkExtractInputPluginTest
     public void validateInputTaskToDateLessThanJobStartTime()
     {
         Date fromDate = new Date(1504224000000L);
-        OffsetDateTime jobStartTime = OffsetDateTime.ofInstant(Instant.ofEpochMilli(1506842144000L), ZoneId.systemDefault());
+        OffsetDateTime jobStartTime = OffsetDateTime.ofInstant(Instant.ofEpochMilli(1506842144000L), ZoneOffset.UTC);
         MarketoBaseBulkExtractInputPlugin.PluginTask pluginTask = Mockito.mock(MarketoBaseBulkExtractInputPlugin.PluginTask.class);
         Mockito.when(pluginTask.getFromDate()).thenReturn(fromDate);
         Mockito.when(pluginTask.getJobStartTime()).thenReturn(jobStartTime);
@@ -112,7 +112,7 @@ public class MarketoBaseBulkExtractInputPluginTest
     public void validateInputTaskFromDateMoreThanJobStartTime()
     {
         Date fromDate = new Date(1507619744000L);
-        OffsetDateTime jobStartTime = OffsetDateTime.ofInstant(Instant.ofEpochMilli(1506842144000L), ZoneId.systemDefault());
+        OffsetDateTime jobStartTime = OffsetDateTime.ofInstant(Instant.ofEpochMilli(1506842144000L), ZoneOffset.UTC);
         MarketoBaseBulkExtractInputPlugin.PluginTask pluginTask = Mockito.mock(MarketoBaseBulkExtractInputPlugin.PluginTask.class);
         Mockito.when(pluginTask.getFromDate()).thenReturn(fromDate);
         Mockito.when(pluginTask.getJobStartTime()).thenReturn(jobStartTime);
@@ -130,7 +130,7 @@ public class MarketoBaseBulkExtractInputPluginTest
     public void validateInputTaskToDateMoreThanJobStartTime()
     {
         Date fromDate = new Date(1504224000000L);
-        OffsetDateTime jobStartTime = OffsetDateTime.ofInstant(Instant.ofEpochMilli(1504396800000L), ZoneId.systemDefault());
+        OffsetDateTime jobStartTime = OffsetDateTime.ofInstant(Instant.ofEpochMilli(1504396800000L), ZoneOffset.UTC);
         MarketoBaseBulkExtractInputPlugin.PluginTask pluginTask = Mockito.mock(MarketoBaseBulkExtractInputPlugin.PluginTask.class);
         Mockito.when(pluginTask.getFromDate()).thenReturn(fromDate);
         Mockito.when(pluginTask.getFetchDays()).thenReturn(7);
@@ -144,8 +144,8 @@ public class MarketoBaseBulkExtractInputPluginTest
     @Test
     public void getToDate()
     {
-        OffsetDateTime date = OffsetDateTime.ofInstant(Instant.ofEpochMilli(1505033728000L), ZoneId.systemDefault());
-        OffsetDateTime jobStartTime = OffsetDateTime.ofInstant(Instant.ofEpochMilli(1507625728000L), ZoneId.systemDefault());
+        OffsetDateTime date = OffsetDateTime.ofInstant(Instant.ofEpochMilli(1505033728000L), ZoneOffset.UTC);
+        OffsetDateTime jobStartTime = OffsetDateTime.ofInstant(Instant.ofEpochMilli(1507625728000L), ZoneOffset.UTC);
         MarketoBaseBulkExtractInputPlugin.PluginTask pluginTask = Mockito.mock(MarketoInputPluginDelegate.PluginTask.class);
         Mockito.when(pluginTask.getFromDate()).thenReturn(Date.from(date.toInstant()));
         Mockito.when(pluginTask.getFetchDays()).thenReturn(30);

--- a/src/test/java/org/embulk/input/marketo/delegate/MarketoBaseBulkExtractInputPluginTest.java
+++ b/src/test/java/org/embulk/input/marketo/delegate/MarketoBaseBulkExtractInputPluginTest.java
@@ -10,7 +10,6 @@ import org.embulk.config.TaskReport;
 import org.embulk.input.marketo.MarketoInputPluginDelegate;
 import org.embulk.input.marketo.MarketoUtils;
 import org.embulk.spi.Schema;
-import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -145,10 +144,10 @@ public class MarketoBaseBulkExtractInputPluginTest
     @Test
     public void getToDate()
     {
-        DateTime date = new DateTime(1505033728000L);
+        OffsetDateTime date = OffsetDateTime.ofInstant(Instant.ofEpochMilli(1505033728000L), ZoneId.systemDefault());
         OffsetDateTime jobStartTime = OffsetDateTime.ofInstant(Instant.ofEpochMilli(1507625728000L), ZoneId.systemDefault());
         MarketoBaseBulkExtractInputPlugin.PluginTask pluginTask = Mockito.mock(MarketoInputPluginDelegate.PluginTask.class);
-        Mockito.when(pluginTask.getFromDate()).thenReturn(date.toDate());
+        Mockito.when(pluginTask.getFromDate()).thenReturn(Date.from(date.toInstant()));
         Mockito.when(pluginTask.getFetchDays()).thenReturn(30);
         Mockito.when(pluginTask.getJobStartTime()).thenReturn(jobStartTime);
         OffsetDateTime toDate = baseBulkExtractInputPlugin.getToDate(pluginTask);

--- a/src/test/java/org/embulk/input/marketo/delegate/MarketoBaseBulkExtractInputPluginTest.java
+++ b/src/test/java/org/embulk/input/marketo/delegate/MarketoBaseBulkExtractInputPluginTest.java
@@ -98,7 +98,7 @@ public class MarketoBaseBulkExtractInputPluginTest
     public void validateInputTaskToDateLessThanJobStartTime()
     {
         Date fromDate = new Date(1504224000000L);
-        OffsetDateTime jobStartTime = OffsetDateTime.ofInstant(Instant.ofEpochSecond(1506842144000L), ZoneId.systemDefault());
+        OffsetDateTime jobStartTime = OffsetDateTime.ofInstant(Instant.ofEpochMilli(1506842144000L), ZoneId.systemDefault());
         MarketoBaseBulkExtractInputPlugin.PluginTask pluginTask = Mockito.mock(MarketoBaseBulkExtractInputPlugin.PluginTask.class);
         Mockito.when(pluginTask.getFromDate()).thenReturn(fromDate);
         Mockito.when(pluginTask.getJobStartTime()).thenReturn(jobStartTime);
@@ -113,7 +113,7 @@ public class MarketoBaseBulkExtractInputPluginTest
     public void validateInputTaskFromDateMoreThanJobStartTime()
     {
         Date fromDate = new Date(1507619744000L);
-        OffsetDateTime jobStartTime = OffsetDateTime.ofInstant(Instant.ofEpochSecond(1506842144000L), ZoneId.systemDefault());
+        OffsetDateTime jobStartTime = OffsetDateTime.ofInstant(Instant.ofEpochMilli(1506842144000L), ZoneId.systemDefault());
         MarketoBaseBulkExtractInputPlugin.PluginTask pluginTask = Mockito.mock(MarketoBaseBulkExtractInputPlugin.PluginTask.class);
         Mockito.when(pluginTask.getFromDate()).thenReturn(fromDate);
         Mockito.when(pluginTask.getJobStartTime()).thenReturn(jobStartTime);
@@ -131,7 +131,7 @@ public class MarketoBaseBulkExtractInputPluginTest
     public void validateInputTaskToDateMoreThanJobStartTime()
     {
         Date fromDate = new Date(1504224000000L);
-        OffsetDateTime jobStartTime = OffsetDateTime.ofInstant(Instant.ofEpochSecond(1504396800000L), ZoneId.systemDefault());
+        OffsetDateTime jobStartTime = OffsetDateTime.ofInstant(Instant.ofEpochMilli(1504396800000L), ZoneId.systemDefault());
         MarketoBaseBulkExtractInputPlugin.PluginTask pluginTask = Mockito.mock(MarketoBaseBulkExtractInputPlugin.PluginTask.class);
         Mockito.when(pluginTask.getFromDate()).thenReturn(fromDate);
         Mockito.when(pluginTask.getFetchDays()).thenReturn(7);
@@ -139,14 +139,14 @@ public class MarketoBaseBulkExtractInputPluginTest
         baseBulkExtractInputPlugin.validateInputTask(pluginTask);
         ArgumentCaptor<Optional<Date>> toDateArgumentCaptor = ArgumentCaptor.forClass(Optional.class);
         Mockito.verify(pluginTask, Mockito.times(1)).setToDate(toDateArgumentCaptor.capture());
-        assertEquals(jobStartTime.toInstant().getEpochSecond(), toDateArgumentCaptor.getValue().get().getTime());
+        assertEquals(jobStartTime.toInstant().toEpochMilli(), toDateArgumentCaptor.getValue().get().getTime());
     }
 
     @Test
     public void getToDate()
     {
         DateTime date = new DateTime(1505033728000L);
-        OffsetDateTime jobStartTime = OffsetDateTime.ofInstant(Instant.ofEpochSecond(1507625728000L), ZoneId.systemDefault());
+        OffsetDateTime jobStartTime = OffsetDateTime.ofInstant(Instant.ofEpochMilli(1507625728000L), ZoneId.systemDefault());
         MarketoBaseBulkExtractInputPlugin.PluginTask pluginTask = Mockito.mock(MarketoInputPluginDelegate.PluginTask.class);
         Mockito.when(pluginTask.getFromDate()).thenReturn(date.toDate());
         Mockito.when(pluginTask.getFetchDays()).thenReturn(30);

--- a/src/test/java/org/embulk/input/marketo/delegate/MarketoBaseBulkExtractInputPluginTest.java
+++ b/src/test/java/org/embulk/input/marketo/delegate/MarketoBaseBulkExtractInputPluginTest.java
@@ -22,6 +22,7 @@ import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Date;
 
@@ -100,7 +101,7 @@ public class MarketoBaseBulkExtractInputPluginTest
         OffsetDateTime jobStartTime = OffsetDateTime.ofInstant(Instant.ofEpochMilli(1506842144000L), ZoneOffset.UTC);
         MarketoBaseBulkExtractInputPlugin.PluginTask pluginTask = Mockito.mock(MarketoBaseBulkExtractInputPlugin.PluginTask.class);
         Mockito.when(pluginTask.getFromDate()).thenReturn(fromDate);
-        Mockito.when(pluginTask.getJobStartTime()).thenReturn(jobStartTime);
+        Mockito.when(pluginTask.getJobStartTime()).thenReturn(jobStartTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
         Mockito.when(pluginTask.getFetchDays()).thenReturn(7);
         baseBulkExtractInputPlugin.validateInputTask(pluginTask);
         ArgumentCaptor<Optional<Date>> argumentCaptor = ArgumentCaptor.forClass(Optional.class);
@@ -115,7 +116,7 @@ public class MarketoBaseBulkExtractInputPluginTest
         OffsetDateTime jobStartTime = OffsetDateTime.ofInstant(Instant.ofEpochMilli(1506842144000L), ZoneOffset.UTC);
         MarketoBaseBulkExtractInputPlugin.PluginTask pluginTask = Mockito.mock(MarketoBaseBulkExtractInputPlugin.PluginTask.class);
         Mockito.when(pluginTask.getFromDate()).thenReturn(fromDate);
-        Mockito.when(pluginTask.getJobStartTime()).thenReturn(jobStartTime);
+        Mockito.when(pluginTask.getJobStartTime()).thenReturn(jobStartTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
 
         try {
             baseBulkExtractInputPlugin.validateInputTask(pluginTask);
@@ -134,7 +135,7 @@ public class MarketoBaseBulkExtractInputPluginTest
         MarketoBaseBulkExtractInputPlugin.PluginTask pluginTask = Mockito.mock(MarketoBaseBulkExtractInputPlugin.PluginTask.class);
         Mockito.when(pluginTask.getFromDate()).thenReturn(fromDate);
         Mockito.when(pluginTask.getFetchDays()).thenReturn(7);
-        Mockito.when(pluginTask.getJobStartTime()).thenReturn(jobStartTime);
+        Mockito.when(pluginTask.getJobStartTime()).thenReturn(jobStartTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
         baseBulkExtractInputPlugin.validateInputTask(pluginTask);
         ArgumentCaptor<Optional<Date>> toDateArgumentCaptor = ArgumentCaptor.forClass(Optional.class);
         Mockito.verify(pluginTask, Mockito.times(1)).setToDate(toDateArgumentCaptor.capture());
@@ -149,7 +150,7 @@ public class MarketoBaseBulkExtractInputPluginTest
         MarketoBaseBulkExtractInputPlugin.PluginTask pluginTask = Mockito.mock(MarketoInputPluginDelegate.PluginTask.class);
         Mockito.when(pluginTask.getFromDate()).thenReturn(Date.from(date.toInstant()));
         Mockito.when(pluginTask.getFetchDays()).thenReturn(30);
-        Mockito.when(pluginTask.getJobStartTime()).thenReturn(jobStartTime);
+        Mockito.when(pluginTask.getJobStartTime()).thenReturn(jobStartTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
         OffsetDateTime toDate = baseBulkExtractInputPlugin.getToDate(pluginTask);
         assertEquals(toDate, jobStartTime);
     }

--- a/src/test/java/org/embulk/input/marketo/delegate/MarketoBaseBulkExtractInputPluginTest.java
+++ b/src/test/java/org/embulk/input/marketo/delegate/MarketoBaseBulkExtractInputPluginTest.java
@@ -22,7 +22,7 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Date;
 
@@ -98,7 +98,7 @@ public class MarketoBaseBulkExtractInputPluginTest
     public void validateInputTaskToDateLessThanJobStartTime()
     {
         Date fromDate = new Date(1504224000000L);
-        OffsetDateTime jobStartTime = OffsetDateTime.ofInstant(Instant.ofEpochSecond(1506842144000L), ZoneOffset.UTC);
+        OffsetDateTime jobStartTime = OffsetDateTime.ofInstant(Instant.ofEpochSecond(1506842144000L), ZoneId.systemDefault());
         MarketoBaseBulkExtractInputPlugin.PluginTask pluginTask = Mockito.mock(MarketoBaseBulkExtractInputPlugin.PluginTask.class);
         Mockito.when(pluginTask.getFromDate()).thenReturn(fromDate);
         Mockito.when(pluginTask.getJobStartTime()).thenReturn(jobStartTime);
@@ -113,7 +113,7 @@ public class MarketoBaseBulkExtractInputPluginTest
     public void validateInputTaskFromDateMoreThanJobStartTime()
     {
         Date fromDate = new Date(1507619744000L);
-        OffsetDateTime jobStartTime = OffsetDateTime.ofInstant(Instant.ofEpochSecond(1506842144000L), ZoneOffset.UTC);
+        OffsetDateTime jobStartTime = OffsetDateTime.ofInstant(Instant.ofEpochSecond(1506842144000L), ZoneId.systemDefault());
         MarketoBaseBulkExtractInputPlugin.PluginTask pluginTask = Mockito.mock(MarketoBaseBulkExtractInputPlugin.PluginTask.class);
         Mockito.when(pluginTask.getFromDate()).thenReturn(fromDate);
         Mockito.when(pluginTask.getJobStartTime()).thenReturn(jobStartTime);
@@ -131,7 +131,7 @@ public class MarketoBaseBulkExtractInputPluginTest
     public void validateInputTaskToDateMoreThanJobStartTime()
     {
         Date fromDate = new Date(1504224000000L);
-        OffsetDateTime jobStartTime = OffsetDateTime.ofInstant(Instant.ofEpochSecond(1504396800000L), ZoneOffset.UTC);
+        OffsetDateTime jobStartTime = OffsetDateTime.ofInstant(Instant.ofEpochSecond(1504396800000L), ZoneId.systemDefault());
         MarketoBaseBulkExtractInputPlugin.PluginTask pluginTask = Mockito.mock(MarketoBaseBulkExtractInputPlugin.PluginTask.class);
         Mockito.when(pluginTask.getFromDate()).thenReturn(fromDate);
         Mockito.when(pluginTask.getFetchDays()).thenReturn(7);
@@ -139,14 +139,14 @@ public class MarketoBaseBulkExtractInputPluginTest
         baseBulkExtractInputPlugin.validateInputTask(pluginTask);
         ArgumentCaptor<Optional<Date>> toDateArgumentCaptor = ArgumentCaptor.forClass(Optional.class);
         Mockito.verify(pluginTask, Mockito.times(1)).setToDate(toDateArgumentCaptor.capture());
-        assertEquals(jobStartTime.toInstant().toEpochMilli(), toDateArgumentCaptor.getValue().get().getTime());
+        assertEquals(jobStartTime.toInstant().getEpochSecond(), toDateArgumentCaptor.getValue().get().getTime());
     }
 
     @Test
     public void getToDate()
     {
         DateTime date = new DateTime(1505033728000L);
-        OffsetDateTime jobStartTime = OffsetDateTime.ofInstant(Instant.ofEpochSecond(1507625728000L), ZoneOffset.UTC);
+        OffsetDateTime jobStartTime = OffsetDateTime.ofInstant(Instant.ofEpochSecond(1507625728000L), ZoneId.systemDefault());
         MarketoBaseBulkExtractInputPlugin.PluginTask pluginTask = Mockito.mock(MarketoInputPluginDelegate.PluginTask.class);
         Mockito.when(pluginTask.getFromDate()).thenReturn(date.toDate());
         Mockito.when(pluginTask.getFetchDays()).thenReturn(30);

--- a/src/test/java/org/embulk/input/marketo/delegate/ProgramInputPluginTest.java
+++ b/src/test/java/org/embulk/input/marketo/delegate/ProgramInputPluginTest.java
@@ -34,6 +34,7 @@ import org.mockito.Mockito;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Date;
@@ -96,7 +97,7 @@ public class ProgramInputPluginTest
     {
         thrown.expect(ConfigException.class);
         thrown.expectMessage("`earliest_updated_at` is required when query by Date Range");
-        ConfigSource config = baseConfig.set("query_by", Optional.of(QueryBy.DATE_RANGE)).set("latest_updated_at", Optional.of(Date.from(OffsetDateTime.now().minusDays(10).toInstant())));
+        ConfigSource config = baseConfig.set("query_by", Optional.of(QueryBy.DATE_RANGE)).set("latest_updated_at", Optional.of(Date.from(OffsetDateTime.now(ZoneOffset.UTC).minusDays(10).toInstant())));
         mockPlugin.validateInputTask(config.loadConfig(PluginTask.class));
     }
 
@@ -105,7 +106,7 @@ public class ProgramInputPluginTest
     {
         thrown.expect(ConfigException.class);
         thrown.expectMessage("`latest_updated_at` is required when query by Date Range");
-        ConfigSource config = baseConfig.set("query_by", Optional.of(QueryBy.DATE_RANGE)).set("earliest_updated_at", Optional.of(Date.from(OffsetDateTime.now().minusDays(10).toInstant())));
+        ConfigSource config = baseConfig.set("query_by", Optional.of(QueryBy.DATE_RANGE)).set("earliest_updated_at", Optional.of(Date.from(OffsetDateTime.now(ZoneOffset.UTC).minusDays(10).toInstant())));
         mockPlugin.validateInputTask(config.loadConfig(PluginTask.class));
     }
 
@@ -117,7 +118,7 @@ public class ProgramInputPluginTest
         ConfigSource config = baseConfig
                         .set("query_by", Optional.of(QueryBy.DATE_RANGE))
                         .set("incremental", Boolean.FALSE)
-                        .set("earliest_updated_at", Optional.of(Date.from(OffsetDateTime.now().minusDays(10).toInstant())));
+                        .set("earliest_updated_at", Optional.of(Date.from(OffsetDateTime.now(ZoneOffset.UTC).minusDays(10).toInstant())));
         mockPlugin.validateInputTask(config.loadConfig(PluginTask.class));
     }
 
@@ -128,7 +129,7 @@ public class ProgramInputPluginTest
                         .set("query_by", Optional.of(QueryBy.DATE_RANGE))
                         .set("report_duration", Optional.of(60L * 1000))
                         .set("incremental", Boolean.FALSE)
-                        .set("earliest_updated_at", Optional.of(Date.from(OffsetDateTime.now().minusDays(10).toInstant())));
+                        .set("earliest_updated_at", Optional.of(Date.from(OffsetDateTime.now(ZoneOffset.UTC).minusDays(10).toInstant())));
         mockPlugin.validateInputTask(config.loadConfig(PluginTask.class));
     }
 
@@ -138,15 +139,15 @@ public class ProgramInputPluginTest
         ConfigSource config = baseConfig
                         .set("report_duration", Optional.of(60L * 1000))
                         .set("query_by", Optional.of(QueryBy.DATE_RANGE))
-                        .set("earliest_updated_at", Optional.of(Date.from(OffsetDateTime.now().minusDays(10).toInstant())));
+                        .set("earliest_updated_at", Optional.of(Date.from(OffsetDateTime.now(ZoneOffset.UTC).minusDays(10).toInstant())));
         mockPlugin.validateInputTask(config.loadConfig(PluginTask.class));
     }
 
     @Test
     public void testQueryByDateRangeConfigHasEarliestUpdatedAtExceededNow()
     {
-        OffsetDateTime earliestUpdatedAt = OffsetDateTime.now().plusDays(1);
-        OffsetDateTime latestUpdatedAt = OffsetDateTime.now().minusDays(2);
+        OffsetDateTime earliestUpdatedAt = OffsetDateTime.now(ZoneOffset.UTC).plusDays(1);
+        OffsetDateTime latestUpdatedAt = OffsetDateTime.now(ZoneOffset.UTC).minusDays(2);
         thrown.expect(ConfigException.class);
         thrown.expectMessage(String.format("`earliest_updated_at` (%s) cannot precede the current date ", earliestUpdatedAt.format(DATE_FORMATTER)));
         ConfigSource config = baseConfig
@@ -159,8 +160,8 @@ public class ProgramInputPluginTest
     @Test
     public void testQueryByDateRangeConfigHasEarliestUpdatedAtExceededLatestUpdatedAt()
     {
-        OffsetDateTime earliestUpdatedAt = OffsetDateTime.now().minusDays(10);
-        OffsetDateTime latestUpdatedAt = OffsetDateTime.now().minusDays(20);
+        OffsetDateTime earliestUpdatedAt = OffsetDateTime.now(ZoneOffset.UTC).minusDays(10);
+        OffsetDateTime latestUpdatedAt = OffsetDateTime.now(ZoneOffset.UTC).minusDays(20);
         thrown.expect(ConfigException.class);
         thrown.expectMessage(String.format("Invalid date range. `earliest_updated_at` (%s) cannot precede the `latest_updated_at` (%s).",
                         earliestUpdatedAt.format(DATE_FORMATTER),
@@ -176,8 +177,8 @@ public class ProgramInputPluginTest
     @Test
     public void testHasFilterTypeButMissingFilterValue()
     {
-        OffsetDateTime earliestUpdatedAt = OffsetDateTime.now().minusDays(20);
-        OffsetDateTime latestUpdatedAt = OffsetDateTime.now().minusDays(10);
+        OffsetDateTime earliestUpdatedAt = OffsetDateTime.now(ZoneOffset.UTC).minusDays(20);
+        OffsetDateTime latestUpdatedAt = OffsetDateTime.now(ZoneOffset.UTC).minusDays(10);
         thrown.expect(ConfigException.class);
         thrown.expectMessage("filter_value is required when selected filter_type");
 
@@ -192,7 +193,7 @@ public class ProgramInputPluginTest
     @Test
     public void testSkipIncrementalRunIfLastUpdatedAtExceedsNow()
     {
-        OffsetDateTime earliestUpdatedAt = OffsetDateTime.now().minusDays(20);
+        OffsetDateTime earliestUpdatedAt = OffsetDateTime.now(ZoneOffset.UTC).minusDays(20);
         OffsetDateTime latestUpdatedAt = earliestUpdatedAt.plusDays(21);
         //21 days
         long reportDuration = 21 * 24 * 60 * 60 * 1000;
@@ -220,8 +221,8 @@ public class ProgramInputPluginTest
     public void testBuildConfigDiff()
     {
         TaskReport taskReport1 = Mockito.mock(TaskReport.class);
-        OffsetDateTime earliestUpdatedAt = OffsetDateTime.now().minusDays(20);
-        OffsetDateTime latestUpdatedAt = OffsetDateTime.now().minusDays(10);
+        OffsetDateTime earliestUpdatedAt = OffsetDateTime.now(ZoneOffset.UTC).minusDays(20);
+        OffsetDateTime latestUpdatedAt = OffsetDateTime.now(ZoneOffset.UTC).minusDays(10);
         ConfigSource config = baseConfig
                         .set("query_by", Optional.of(QueryBy.DATE_RANGE))
                         .set("earliest_updated_at", Optional.of(Date.from(earliestUpdatedAt.toInstant())))
@@ -299,8 +300,8 @@ public class ProgramInputPluginTest
     @Test
     public void testRunQueryByDateRange() throws IOException
     {
-        OffsetDateTime earliestUpdatedAt = OffsetDateTime.now().minusDays(20);
-        OffsetDateTime latestUpdatedAt = OffsetDateTime.now().minusDays(10);
+        OffsetDateTime earliestUpdatedAt = OffsetDateTime.now(ZoneOffset.UTC).minusDays(20);
+        OffsetDateTime latestUpdatedAt = OffsetDateTime.now(ZoneOffset.UTC).minusDays(10);
         ConfigSource config = baseConfig
                         .set("query_by", Optional.of(QueryBy.DATE_RANGE))
                         .set("earliest_updated_at", Optional.of(Date.from(earliestUpdatedAt.toInstant())))


### PR DESCRIPTION
**Summary:**

-  Replace Joda-Time with java.time classes.
-  Use GitHub Action instead of Travis CI.


### Are all connections created by the plugin secure?

- [x] Does it opt secure communication standard? Such as HTTPS, SSH, SFTP, SMTP STARTTLS. If not check with CISO to decide we can deploy the plugin.
- [x] Does support both authentication and encryption appropriately? Such as: "just encrypting without authentication" that is insecure.

### Does the plugin connect only to its expected external site which the customer explicitly set in their config file?

- [x] Does NOT connect unexpected external site and our internal endpoints? Such as: “v3/job/:id/set_started” callback endpoint.

### Does NOT the plugin persist any customers' private information? Identify the private information beforehand.

- [x] Does NOT include them in (temporary) files?
- [x] Does NOT include them in log messages and exception messages?

### What kind of environments does the plugin interact with?

- [x] Does NOT execute any shell command?
- [x] Does NOT read any files on the running instance? Such as: "/etc/passwords". It’s ok to read temporary files that the plugin wrote.
- [x] Does use to create temporary files by spi.TempFileSpace utility to avoid the conflict of the file names.
- [x] Does NOT get environment variables or JVM system properties at runtime? Such as AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY in environment variables

### Does NOT the plugin use insecure libraries?

- [x] Line up all depending library so that we can identify the impact of security incident of those library if any.
- [x] Check libraries usage of the plugin; all security check list must apply to the library usages. Such as "Are all connections created by the library secure?"

### Does NOT the plugin source code repository contain kinds of credentials

- [x] API keys
- [x] Passwords

### Make sure to free up all resources allocated during Embulk transaction “committing” or “rolling back”or before.

- [x] Network (connections, pooled connections)
- [x] Memory (cache in static variables)
- [x] File (temporary files)
- [x] CPU (threads, processes)