### PR TITLE
Fix resource leak when import program members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.6.25 - 2022-09-21
+- Properly shutdown ThreadExecutor when an unexpected error occurs
+
 ## 0.6.24 - 2021-10-19
 - Add retryable in case response data invalid json format
 

--- a/src/main/java/org/embulk/input/marketo/delegate/ProgramMembersBulkExtractInputPlugin.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/ProgramMembersBulkExtractInputPlugin.java
@@ -2,6 +2,7 @@ package org.embulk.input.marketo.delegate;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.StringUtils;
 import org.embulk.base.restclient.ServiceResponseMapper;
 import org.embulk.base.restclient.record.RecordImporter;
@@ -150,72 +151,29 @@ public class ProgramMembersBulkExtractInputPlugin extends MarketoBaseInputPlugin
             if (!task.getProgramMemberFields().isPresent() || !task.getExtractedProgramIds().isPresent()) {
                 throw new ConfigException("program_member_fields or extracted_programs are missing.");
             }
-            ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(task.getNumberConcurrentExportJob());
-            final MarketoRestClient restClient = createMarketoRestClient(task);
-            final List<String> fieldNames = new ArrayList<>(task.getProgramMemberFields().get().keySet());
+            ThreadPoolExecutor executor = createExecutor(task);
+            try {
+                final MarketoRestClient restClient = createMarketoRestClient(task);
+                final List<String> fieldNames = new ArrayList<>(task.getProgramMemberFields().get().keySet());
 
-            List<Future> listFutureExportIDs = task.getExtractedProgramIds().get().stream()
-                .map(programId -> {
-                    Runnable exportTask = () -> {
-                        String exportJobID = restClient.createProgramMembersBulkExtract(fieldNames, programId);
-                        restClient.startProgramMembersBulkExtract(exportJobID);
-                        int numberRecord;
-                        try {
-                            ObjectNode status = restClient.waitProgramMembersExportJobComplete(exportJobID, task.getPollingIntervalSecond(), task.getBulkJobTimeoutSecond());
-                            numberRecord = status.get("numberOfRecords").asInt();
-                        }
-                        catch (InterruptedException e) {
-                            logger.error("Exception when waiting for export program [{}], job id [{}]", programId, exportJobID, e);
-                            throw new DataException(e);
-                        }
-                        if (numberRecord == 0) {
-                            logger.info("Export program [{}], job [{}] have no record.", programId, exportJobID);
-                            return;
-                        }
-                        MarketoService marketoService = new MarketoServiceImpl(restClient);
-                        LineDecoder lineDecoder = null;
-                        try {
-                            InputStream extractedStream = new FileInputStream(marketoService.extractProgramMembers(exportJobID));
-                            lineDecoder = LineDecoder.of(new InputStreamFileInput(Exec.getBufferAllocator(), extractedStream), StandardCharsets.UTF_8, null);
-                            Iterator<Map<String, String>> csvRecords = new CsvRecordIterator(lineDecoder, task);
-                            int imported = 0;
-                            while (csvRecords.hasNext()) {
-                                Map<String, String> csvRecord = csvRecords.next();
-                                ObjectNode objectNode = MarketoUtils.OBJECT_MAPPER.valueToTree(csvRecord);
-                                recordImporter.importRecord(new AllStringJacksonServiceRecord(objectNode), pageBuilder);
-                                imported = imported + 1;
-                            }
+                List<Future> listFutureExportIDs = task.getExtractedProgramIds().get().stream()
+                                                       .map(programId -> createFutureTask(task, recordImporter, pageBuilder, executor, restClient, fieldNames, programId))
+                                                       .collect(Collectors.toList());
 
-                            logger.info("Import data for program [{}], job_id [{}] finish.[{}] records imported/total [{}]", programId, exportJobID, imported, numberRecord);
-                        }
-                        catch (FileNotFoundException e) {
-                            throw new RuntimeException("File export cannot be found", e);
-                        }
-                        finally {
-                            if (lineDecoder != null) {
-                                lineDecoder.close();
-                            }
-                        }
-                    };
-                    return executor.submit(exportTask);
-                })
-                .collect(Collectors.toList());
-
-            for (Future future : listFutureExportIDs) {
-                try {
-                    future.get();
-                }
-                catch (InterruptedException | ExecutionException ex) {
-                    logger.error("Exception occur. Shutdown execute service.........", ex);
-                    if (executor != null && !executor.isShutdown()) {
-                        executor.shutdownNow();
+                for (Future future : listFutureExportIDs) {
+                    try {
+                        future.get();
                     }
-                    throw new RuntimeException(ex);
+                    catch (InterruptedException | ExecutionException ex) {
+                        throw new RuntimeException(ex);
+                    }
                 }
+                restClient.close();
             }
-            restClient.close();
-            if (executor != null && !executor.isShutdown()) {
-                executor.shutdownNow();
+            finally {
+                if (!executor.isShutdown()) {
+                    executor.shutdownNow();
+                }
             }
             return taskReport;
         }

--- a/src/main/java/org/embulk/input/marketo/delegate/ProgramMembersBulkExtractInputPlugin.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/ProgramMembersBulkExtractInputPlugin.java
@@ -229,7 +229,10 @@ public class ProgramMembersBulkExtractInputPlugin extends MarketoBaseInputPlugin
             }
         };
 
-        return executor.submit(exportTask);
+        Thread exportThread = new Thread(exportTask);
+        exportThread.setDaemon(true);
+
+        return executor.submit(exportThread);
     }
 
     @Override

--- a/src/main/java/org/embulk/input/marketo/delegate/ProgramMembersBulkExtractInputPlugin.java
+++ b/src/main/java/org/embulk/input/marketo/delegate/ProgramMembersBulkExtractInputPlugin.java
@@ -151,9 +151,10 @@ public class ProgramMembersBulkExtractInputPlugin extends MarketoBaseInputPlugin
             if (!task.getProgramMemberFields().isPresent() || !task.getExtractedProgramIds().isPresent()) {
                 throw new ConfigException("program_member_fields or extracted_programs are missing.");
             }
-            ThreadPoolExecutor executor = createExecutor(task);
+            final ThreadPoolExecutor executor = createExecutor(task);
+            final MarketoRestClient restClient = createMarketoRestClient(task);
+
             try {
-                final MarketoRestClient restClient = createMarketoRestClient(task);
                 final List<String> fieldNames = new ArrayList<>(task.getProgramMemberFields().get().keySet());
 
                 List<Future> listFutureExportIDs = task.getExtractedProgramIds().get().stream()
@@ -168,9 +169,9 @@ public class ProgramMembersBulkExtractInputPlugin extends MarketoBaseInputPlugin
                         throw new RuntimeException(ex);
                     }
                 }
-                restClient.close();
             }
             finally {
+                restClient.close();
                 if (!executor.isShutdown()) {
                     executor.shutdownNow();
                 }


### PR DESCRIPTION
### Are all connections created by the plugin secure?

- [ ] Does it opt secure communication standard? Such as HTTPS, SSH, SFTP, SMTP STARTTLS. If not check with CISO to decide we can deploy the plugin.
- [ ] Does support both authentication and encryption appropriately? Such as: "just encrypting without authentication" that is insecure.

### Does the plugin connect only to its expected external site which the customer explicitly set in their config file?

- [ ] Does NOT connect unexpected external site and our internal endpoints? Such as: “v3/job/:id/set_started” callback endpoint.

### Does NOT the plugin persist any customers' private information? Identify the private information beforehand.

- [ ] Does NOT include them in (temporary) files?
- [ ] Does NOT include them in log messages and exception messages?

### What kind of environments does the plugin interact with?

- [ ] Does NOT execute any shell command?
- [ ] Does NOT read any files on the running instance? Such as: "/etc/passwords". It’s ok to read temporary files that the plugin wrote.
- [ ] Does use to create temporary files by spi.TempFileSpace utility to avoid the conflict of the file names.
- [ ] Does NOT get environment variables or JVM system properties at runtime? Such as AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY in environment variables

### Does NOT the plugin use insecure libraries?

- [ ] Line up all depending library so that we can identify the impact of security incident of those library if any.
- [ ] Check libraries usage of the plugin; all security check list must apply to the library usages. Such as "Are all connections created by the library secure?"

### Does NOT the plugin source code repository contain kinds of credentials

- [ ] API keys
- [ ] Passwords

### Make sure to free up all resources allocated during Embulk transaction “committing” or “rolling back”or before.

- [ ] Network (connections, pooled connections)
- [ ] Memory (cache in static variables)
- [ ] File (temporary files)
- [ ] CPU (threads, processes)