### PR TITLE
Fix issue response header Marketo change from text/csv to text/csv;charset=UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.6.27
+- Fix issue response header Marketo change from text/csv to text/csv;charset=UTF-8
+
 ## 0.6.26
 - Catch up to Java 11
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ repositories {
 
 group = "com.treasuredata.embulk.plugins"
 description = "Loads records from Marketo."
-version = "0.6.26"
+version = "0.6.27"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/java/org/embulk/input/marketo/rest/MarketoInputStreamResponseEntityReader.java
+++ b/src/main/java/org/embulk/input/marketo/rest/MarketoInputStreamResponseEntityReader.java
@@ -48,7 +48,7 @@ public class MarketoInputStreamResponseEntityReader implements Jetty94ResponseRe
     @Override
     public InputStream readResponseContent() throws Exception
     {
-        if (!getResponse().getHeaders().getField(HttpHeader.CONTENT_TYPE).getValue().equals("text/csv")) {
+        if (!getResponse().getHeaders().getField(HttpHeader.CONTENT_TYPE).getValue().contains("text/csv")) {
             String errorString = readResponseContentInString();
 
             MarketoResponse<ObjectNode> errorResponse = OBJECT_READER.readValue(errorString);


### PR DESCRIPTION
### Are all connections created by the plugin secure?

- [x] Does it opt secure communication standard? Such as HTTPS, SSH, SFTP, SMTP STARTTLS. If not check with CISO to decide we can deploy the plugin.
- [x] Does support both authentication and encryption appropriately? Such as: "just encrypting without authentication" that is insecure.

### Does the plugin connect only to its expected external site which the customer explicitly set in their config file?

- [x] Does NOT connect unexpected external site and our internal endpoints? Such as: “v3/job/:id/set_started” callback endpoint.

### Does NOT the plugin persist any customers' private information? Identify the private information beforehand.

- [x] Does NOT include them in (temporary) files?
- [x] Does NOT include them in log messages and exception messages?

### What kind of environments does the plugin interact with?

- [x] Does NOT execute any shell command?
- [x] Does NOT read any files on the running instance? Such as: "/etc/passwords". It’s ok to read temporary files that the plugin wrote.
- [x] Does use to create temporary files by spi.TempFileSpace utility to avoid the conflict of the file names.
- [x] Does NOT get environment variables or JVM system properties at runtime? Such as AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY in environment variables

### Does NOT the plugin use insecure libraries?

- [x] Line up all depending library so that we can identify the impact of security incident of those library if any.
- [x] Check libraries usage of the plugin; all security check list must apply to the library usages. Such as "Are all connections created by the library secure?"

### Does NOT the plugin source code repository contain kinds of credentials

- [x] API keys
- [x] Passwords

### Make sure to free up all resources allocated during Embulk transaction “committing” or “rolling back”or before.

- [x] Network (connections, pooled connections)
- [x] Memory (cache in static variables)
- [x] File (temporary files)
- [x] CPU (threads, processes)